### PR TITLE
Make hints more consistent

### DIFF
--- a/R/code_feedback.R
+++ b/R/code_feedback.R
@@ -372,7 +372,11 @@ give_code_feedback_.gradethis_graded <- function(
     maybe_code_feedback(user_code, solution_code, ...)
   )
   
-  if (identical(feedback, "")) signal_grade(grade)
+  # If there isn't any feedback or if the feedback message has already been
+  # added to the grade message, then just re-throw the grade
+  if (identical(feedback, "") || grepl(feedback, grade$message, fixed = TRUE)) {
+    signal_grade(grade)
+  }
   
   before <- identical(location, "before")
   grade$message <- paste0(

--- a/R/graded.R
+++ b/R/graded.R
@@ -252,8 +252,23 @@ fail <- function(
   hint = getOption("gradethis.fail.hint", FALSE),
   encourage = getOption("gradethis.fail.encourage", FALSE)
 ) {
+  user_provided_hint <- !missing(hint)
+  user_provided_message <- !missing(message)
+  
+  this_fail_grade <- function() {
+    if (user_provided_hint && !user_provided_message) {
+      # allow hint = FALSE, provided by the user, to override the default message
+      with_maybe_code_feedback(
+        isTRUE(hint),
+        graded(message = glue_message_with_env(env, message), correct = FALSE, ...)
+      )
+    } else {
+      graded(message = glue_message_with_env(env, message), correct = FALSE, ...)
+    }
+  }
+  
   maybe_extras(
-    graded(message = glue_message_with_env(env, message), correct = FALSE, ...),
+    this_fail_grade(),
     env = env,
     hint = hint,
     encourage = encourage

--- a/man/gradethis-package.Rd
+++ b/man/gradethis-package.Rd
@@ -7,6 +7,8 @@
 \title{gradethis: Automated Feedback for Student Exercises in 'learnr'
     Tutorials}
 \description{
+\if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
+
 Pairing with the 'learnr' R package, 'gradethis'
     provides multiple methods to grade 'learnr' exercises.  To learn more
     about 'learnr' tutorials, please visit

--- a/tests/testthat/test-code_feedback.R
+++ b/tests/testthat/test-code_feedback.R
@@ -659,14 +659,14 @@ test_that("fail() message doesn't duplicate hints", {
   expect_fail_message <- function(expr, global_hint_true, global_hint_false = global_hint_true) {
     expr <- rlang::enexpr(expr)
     msg <- list(
-      global_hint_true = withr::with_options(
+      global_hint_true = with_options(
         list(
           gradethis.fail.hint = TRUE, 
           gradethis.fail = "PREFACE.{maybe_code_feedback()} CONCLUSION"
         ),
         rlang::eval_bare(expr)$message
       ),
-      global_hint_false = withr::with_options(
+      global_hint_false = with_options(
         list(
           gradethis.fail.hint = FALSE, 
           gradethis.fail = "PREFACE.{maybe_code_feedback()} CONCLUSION"


### PR DESCRIPTION
Fixes #243

We had a few inconsisntencies in how hints -- a.k.a. code feedback -- were added to feedback messages.

We effectively have many methods of adding hints:

- Actively in the message template: `fail("{maybe_code_feedback()}")`
- Semi-actively in the default message template: `gradethis_setup(fail = "{maybe_code_feedback()}")`
- Actively suppressing the hint in the call to `fail()` with a default message: `fail(hint = FALSE)`
- Passively in the call to `fail()` with a non-default message: `fail("Not quite.", hint = TRUE)`
- Extra-passively with the global option: `gradethis_setup(fail.hint = TRUE)`

This PR favors earlier active methods over later passive methods and ensures that feedback is only added once. The feedback template string is seens as the most "active" way to signal an intent to include code feedback. 

In all circumstances, when `hint = TRUE` (either locally or globally), the hint will appear where `"{maybe_code_feedback()}"` appears in the template string, or at the end if not part of the template.

If `"{maybe_code_feedback()}"` appears in the default fail feedback message, then code feedback will always appear unless the user explicitly sets `hint = FALSE`.

The full behavior with the interaction of all possible options is covered in `test-code_feedback.R`.

