### PR TITLE
Allow graded() to add additional data to the feedback via ...

### DIFF
--- a/R/feedback.R
+++ b/R/feedback.R
@@ -41,16 +41,23 @@ feedback <- function(
         "custom"
       }
   }
-
-  structure(
-    list(
-      message = message_md(grade$message),
-      correct = grade$correct,
-      type = type,
-      location = location
-    ),
-    class = "gradethis_feedback"
+  
+  feedback <- list(
+    message = message_md(grade$message),
+    correct = grade$correct,
+    type = type,
+    location = location
   )
+  
+  learnr_std_feedback <- which(names(grade) %in% c("message", "correct", "type", "location"))
+  extra <- grade[-learnr_std_feedback]
+  
+  if (length(extra)) {
+    checkmate::assert_names(names(extra), "unique", .var.name = "extra data in `grade`")
+    feedback <- c(feedback, extra)
+  }
+
+  structure(feedback, class = "gradethis_feedback")
 }
 
 

--- a/R/graded.R
+++ b/R/graded.R
@@ -181,17 +181,21 @@
 #' @describeIn graded Prepare and signal a graded result.
 #' @export
 graded <- function(correct, message = NULL, ..., type = NULL, location = NULL) {
-  ellipsis::check_dots_empty()
-
+  if (length(list(...))) {
+    # ... must be unique and named
+    checkmate::assert_names(names(list(...)), "unique", .var.name = "...")
+  }
+  
   # allow logical(0) to signal a neutral grade
-  checkmate::expect_logical(correct, any.missing = FALSE, max.len = 1, null.ok = FALSE)
+  checkmate::assert_logical(correct, any.missing = FALSE, max.len = 1, null.ok = FALSE)
 
   obj <- structure(
     list(
       message = message %||% "",
       correct = correct,
       type = type,
-      location = location
+      location = location,
+      ...
     ),
     class = c("gradethis_graded", "condition")
   )
@@ -480,7 +484,7 @@ grade_if_equal <- function(x, y, message, correct, env, ...) {
 #'   an `if (cond)` statement, then a passing or failing grade is returned to
 #'   the user.
 #' @param x Deprecated. Replaced with `cond`.
-#' @param ... Ignored
+#' @param ... Passed to [graded()] in [grade_this()].
 #' @inheritParams graded
 #' 
 #' @return `pass_if()` and `fail_if()` signal a correct or incorrect grade if
@@ -497,7 +501,6 @@ pass_if <- function(
   praise = getOption("gradethis.pass.praise", FALSE),
   x = deprecated()
 ) {
-  ellipsis::check_dots_empty()
 
   if (is_present(x)) {
     deprecate_warn(
@@ -514,7 +517,7 @@ pass_if <- function(
     assert_gradethis_condition_type_is_value(cond, "pass_if")
     if (cond) {
       message <- message %||% getOption("gradethis.pass", "Correct!")
-      maybe_extras(pass(message, env = env), praise = praise)
+      maybe_extras(pass(message, env = env, ...), praise = praise)
     }
   } else {
     condition(cond, message, correct = TRUE)
@@ -532,8 +535,6 @@ fail_if <- function(
   encourage = getOption("gradethis.fail.encourage", FALSE),
   x = deprecated()
 ) {
-  ellipsis::check_dots_empty()
-
   if (is_present(x)) {
     deprecate_warn(
       "0.2.3",
@@ -550,7 +551,7 @@ fail_if <- function(
     if (cond) {
       message <- message %||% getOption("gradethis.fail", "Inorrect.")
       maybe_extras(
-        fail(message, env = env),
+        fail(message, env = env, ...),
         env = env,
         hint = hint,
         encourage = encourage

--- a/R/graded.R
+++ b/R/graded.R
@@ -162,7 +162,8 @@
 #'   grading helper functions other than [graded()], `message` is a template
 #'   string that will be processed with [glue::glue()].
 #' @param correct A logical value of whether or not the checked code is correct.
-#' @param ... Additional arguments passed to `graded()` or otherwise ignored.
+#' @param ... Additional arguments passed to `graded()` or additional data to be
+#'   included in the feedback object.
 #' @param type,location The `type` and `location` of the feedback object
 #'   provided to \pkg{learnr}. See
 #'   <https://rstudio.github.io/learnr/exercises.html#Custom_checking> for more

--- a/man/graded.Rd
+++ b/man/graded.Rd
@@ -30,7 +30,8 @@ fail(
 grading helper functions other than \code{\link[=graded]{graded()}}, \code{message} is a template
 string that will be processed with \code{\link[glue:glue]{glue::glue()}}.}
 
-\item{...}{Additional arguments passed to \code{graded()} or otherwise ignored.}
+\item{...}{Additional arguments passed to \code{graded()} or additional data to be
+included in the feedback object.}
 
 \item{type, location}{The \code{type} and \code{location} of the feedback object
 provided to \pkg{learnr}. See

--- a/man/pass_if.Rd
+++ b/man/pass_if.Rd
@@ -34,7 +34,7 @@ the user.}
 grading helper functions other than \code{\link[=graded]{graded()}}, \code{message} is a template
 string that will be processed with \code{\link[glue:glue]{glue::glue()}}.}
 
-\item{...}{Ignored}
+\item{...}{Passed to \code{\link[=graded]{graded()}}.}
 
 \item{env}{environment to evaluate the glue \code{message}. Most users of
 \pkg{gradethis} will not need to use this argument.}

--- a/man/pass_if.Rd
+++ b/man/pass_if.Rd
@@ -34,7 +34,7 @@ the user.}
 grading helper functions other than \code{\link[=graded]{graded()}}, \code{message} is a template
 string that will be processed with \code{\link[glue:glue]{glue::glue()}}.}
 
-\item{...}{Passed to \code{\link[=graded]{graded()}}.}
+\item{...}{Passed to \code{\link[=graded]{graded()}} in \code{\link[=grade_this]{grade_this()}}.}
 
 \item{env}{environment to evaluate the glue \code{message}. Most users of
 \pkg{gradethis} will not need to use this argument.}

--- a/tests/testthat/test-feedback.R
+++ b/tests/testthat/test-feedback.R
@@ -232,3 +232,31 @@ test_that("feedback() prefers graded options over feedback options", {
     msg = "test"
   )
 })
+
+test_that("feedback() passes along extra information in the from graded()", {
+  expect_equal(feedback(graded(TRUE, "foo", arg = "boom!"))$arg, "boom!")
+  expect_equal(feedback(graded(TRUE, "foo", prop = list(a = "apple")))$prop, list(a = "apple"))
+  expect_equal(feedback(pass("msg", prop = 42))$prop, 42)
+  expect_equal(feedback(fail("msg", prop = 42))$prop, 42)
+  
+  gradethis_env <- rlang::env(".__gradethis_check_env" = TRUE)
+  expect_equal(feedback(pass_if(TRUE, "msg", prop = 42, env = gradethis_env))$prop, 42)
+  expect_equal(feedback(fail_if(TRUE, "msg", prop = 42, env = gradethis_env))$prop, 42)
+  
+  expect_equal(feedback(pass_if_equal(x = 1, y = 1, "msg", prop = 42))$prop, 42)
+  expect_equal(feedback(fail_if_equal(x = 1, y = 1, "msg", prop = 42))$prop, 42)
+  expect_equal(feedback(fail_if_code_feedback("msg", "a", "b", prop = 42))$prop, 42)
+  
+  # ... need to be named (if we somehow get around checks in graded())
+  grade <- graded(TRUE, "foo", foo = "boom!")
+  names(grade)[5] <- NA_character_
+  expect_error(feedback(grade))
+  names(grade)[5] <- ""
+  expect_error(feedback(grade))
+  
+  # ... need to be unique (if we somehow get around checks in graded())
+  grade <- graded(TRUE, "foo", prop = 2, prop2 = 3)
+  names(grade)[6] <- "prop"
+  expect_error(feedback(grade))
+})
+

--- a/tests/testthat/test-graded.R
+++ b/tests/testthat/test-graded.R
@@ -292,9 +292,24 @@ test_that("graded() returns correct, incorrect, neutral", {
   expect_error(graded("boom", I("bad")))
 })
 
-test_that("graded() ensures that ... are empty", {
-  expect_error(graded(TRUE, "foo", arg = "boom!"))
+test_that("graded() passes along extra information in the ...", {
+  expect_equal(graded(TRUE, "foo", arg = "boom!")$arg, "boom!")
+  expect_equal(graded(TRUE, "foo", prop = list(a = "apple"))$prop, list(a = "apple"))
+  expect_equal(pass("msg", prop = 42)$prop, 42)
+  expect_equal(fail("msg", prop = 42)$prop, 42)
+  
+  gradethis_env <- rlang::env(".__gradethis_check_env" = TRUE)
+  expect_equal(pass_if(TRUE, "msg", prop = 42, env = gradethis_env)$prop, 42)
+  expect_equal(fail_if(TRUE, "msg", prop = 42, env = gradethis_env)$prop, 42)
+    
+  expect_equal(pass_if_equal(x = 1, y = 1, "msg", prop = 42)$prop, 42)
+  expect_equal(fail_if_equal(x = 1, y = 1, "msg", prop = 42)$prop, 42)
+  expect_equal(fail_if_code_feedback("msg", "a", "b", prop = 42)$prop, 42)
+  
+  # ... need to be named
   expect_error(graded(TRUE, "foo", "boom!"))
+  # ... need to be unique
+  expect_error(graded(TRUE, "foo", prop = 2, prop = 3))
 })
 
 test_that("pass_if() and fail_if() use default pass/fail message in grade_this()", {


### PR DESCRIPTION
This PR lifts the restriction that the `...` in `graded()` must not be used. It also lets extra information pass through from `graded()` to the learnr feedback object, where learnr just passes it along as well.

There are only two requirements:

1. The `...` must all be named (and implicitly not `correct`, `message`, `type` or `location`).
2. The `...` names must be unique.

These requirements are checked both in `graded()` and in `feedback()`.

A potential use case might be to annotate the types of feedback:

```r
grade <- fail("Oops!", failure_mode = "used integer")
grade$failure_mode
#> [1] "used integer"
```