### PR TITLE
Use `https` for image to avoid netlify mixed content warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CRAN status](https://www.r-pkg.org/badges/version/gradethis)](https://CRAN.R-project.org/package=gradethis)
 [![R build status](https://github.com/rstudio/gradethis/workflows/R-CMD-check/badge.svg)](https://github.com/rstudio/gradethis/actions)
 [![Codecov test coverage](https://codecov.io/gh/rstudio/gradethis/branch/master/graph/badge.svg)](https://codecov.io/gh/rstudio/gradethis?branch=master)
-[![gradethis downloads per month](http://cranlogs.r-pkg.org/badges/gradethis)](http://www.rpackages.io/package/gradethis)
+[![gradethis downloads per month](https://cranlogs.r-pkg.org/badges/gradethis)](http://www.rpackages.io/package/gradethis)
 [![DOI](https://zenodo.org/badge/126734088.svg)](https://zenodo.org/badge/latestdoi/126734088)
 <!-- badges: end -->
 


### PR DESCRIPTION
```
1:31:32 PM: Post processing - HTML
1:31:34 PM: Mixed content detected in: /index.html
1:31:34 PM: --> insecure img urls:
1:31:34 PM:   - http://cranlogs.r-pkg.org/badges/gradethis
```