### PR TITLE
Make grading problem message and type configurable

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^sandbox$
 ^LICENSE\.md$
 ^CODE_OF_CONDUCT\.md$
+^_dev$

--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@
 * The `space_before` and `space_after` arguments of `maybe_code_feedback()` have been deprecated in favor of more flexible arguments `before` and `after` that accept arbitrary strings to add before or after the message. (#219)
 * The `x` argument of `pass_if()` and `fail_if()` has been renamed `cond` and both functions now work inside `grade_this()`, although the function and formula versions are not supported there. (#216)
 * `grade_this()` no longer automatically converts errors to `fail()` grades, instead authors need to wrap unit-test-style code in `fail_if_error()` to convert them to grades. This helps to better differentiate between unexpected errors resulting from the author's grading code and portions of the grading code where errors are expected and indicative of a problem with the user's code. (#254)
+* Errors in the grading code are now returned as _neutral_ grades rather than failing grades. The feedback message and type can be changed with two new arguments to `gradethis_setup()`: `grading_problem.message` and `grading_problem.type` (#256).
 
 ### Bug fixes
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/feedback.R
+++ b/R/feedback.R
@@ -134,7 +134,7 @@ feedback_grading_problem <- function(message = NULL, type = NULL, error = NULL) 
   
   error <- unclass(error)
   
-  feedback(fail(message, error = error), type = type)
+  feedback(graded(logical(), message, type = type, error = error))
 }
 
 grade_grading_problem <- function(message = NULL, error = NULL, correct = logical(), type = NULL, ...) {

--- a/R/feedback.R
+++ b/R/feedback.R
@@ -117,8 +117,11 @@ feedback_grading_problem_validate_type <- function(type) {
   tryCatch(
     match.arg(type, c("success", "info", "warning", "error", "custom")),
     error = function(e) {
-      message('`gradethis_problem.type` should be one of "success", "info", "warning", "error", "custom"')
-      gradethis_settings$grading_problem.type()
+      message(
+        '`gradethis_problem.type` should be one of "success", "info", "warning", "error", "custom". ',
+        'Defaulting to "', gradethis_default_options[["grading_problem.type"]], '".'
+      )
+      gradethis_default_options[["grading_problem.type"]]
     }
   )
 }

--- a/R/feedback.R
+++ b/R/feedback.R
@@ -113,10 +113,9 @@ remove_dangerous_html_tags <- function(md) {
   )
 }
 
-feedback_grading_problem_message <- "A problem occurred with your teacher's grading code."
-
-feedback_grading_problem <- function(message = NULL, type = "error", error = NULL) {
-  message <- message %||% paste(feedback_grading_problem_message,  "Defaulting to _incorrect_.")
+feedback_grading_problem <- function(message = NULL, type = NULL, error = NULL) {
+  message <- message %||% gradethis_settings$grading_problem.message()
+  type <- type %||% gradethis_settings$grading_problem.type()
   
   if (is.call(error$call)) {
     error$call <- paste(deparse(error$call), collapse = "\n")
@@ -127,8 +126,9 @@ feedback_grading_problem <- function(message = NULL, type = "error", error = NUL
   feedback(fail(message, error = error), type = type)
 }
 
-grade_grading_problem <- function(message = NULL, error = NULL, correct = logical(), type = "warning", ...) {
-  message <- message %||% feedback_grading_problem_message
+grade_grading_problem <- function(message = NULL, error = NULL, correct = logical(), type = NULL, ...) {
+  message <- message %||% gradethis_settings$grading_problem.message()
+  type <- type %||% gradethis_settings$grading_problem.type()
   
   if (is.call(error$call)) {
     error$call <- paste(deparse(error$call), collapse = "\n")

--- a/R/feedback.R
+++ b/R/feedback.R
@@ -113,9 +113,20 @@ remove_dangerous_html_tags <- function(md) {
   )
 }
 
+feedback_grading_problem_validate_type <- function(type) {
+  tryCatch(
+    match.arg(type, c("success", "info", "warning", "error", "custom")),
+    error = function(e) {
+      message('`gradethis_problem.type` should be one of "success", "info", "warning", "error", "custom"')
+      gradethis_settings$grading_problem.type()
+    }
+  )
+}
+
 feedback_grading_problem <- function(message = NULL, type = NULL, error = NULL) {
   message <- message %||% gradethis_settings$grading_problem.message()
   type <- type %||% gradethis_settings$grading_problem.type()
+  type <- feedback_grading_problem_validate_type(type)
   
   if (is.call(error$call)) {
     error$call <- paste(deparse(error$call), collapse = "\n")
@@ -129,6 +140,7 @@ feedback_grading_problem <- function(message = NULL, type = NULL, error = NULL) 
 grade_grading_problem <- function(message = NULL, error = NULL, correct = logical(), type = NULL, ...) {
   message <- message %||% gradethis_settings$grading_problem.message()
   type <- type %||% gradethis_settings$grading_problem.type()
+  type <- feedback_grading_problem_validate_type(type)
   
   if (is.call(error$call)) {
     error$call <- paste(deparse(error$call), collapse = "\n")

--- a/R/gradethis_setup.R
+++ b/R/gradethis_setup.R
@@ -135,6 +135,10 @@ gradethis_setup <- function(
     }
   }
   
+  if (!is.null(grading_problem.type)) {
+    set_opts[["grading_problem.type"]] <- feedback_grading_problem_validate_type(grading_problem.type)
+  }
+  
   learnr_opts <- names(gradethis_default_learnr_options)
   gradethis_opts <- names(gradethis_default_options)
   

--- a/R/gradethis_setup.R
+++ b/R/gradethis_setup.R
@@ -243,3 +243,34 @@ gradethis_default_learnr_options <- list(
   exercise.checker = gradethis_exercise_checker,
   exercise.error.check.code = "gradethis_error_checker()"
 )
+
+gradethis_settings <- (function() {
+  gradethis_settings <- list()
+  for (gt_opt in names(gradethis_default_options)) {
+    gradethis_settings[[gt_opt]] <- (function(x_opt, x_name) {
+      force(list(x_opt, x_name))
+      function() {
+        getOption(x_opt, gradethis_default_options[[x_name]])
+      }
+    })(paste0("gradethis.", gt_opt), gt_opt)
+  }
+  for (gt_legacy_opt in names(gradethis_legacy_options)) {
+    gt_opt <- sub("^gradethis[.]", "", gt_legacy_opt)
+    gradethis_settings[[gt_opt]] <- (function(x_opt, x_name) {
+      force(list(x_opt, x_name))
+      function() {
+        getOption(x_opt, gradethis_legacy_options[[x_name]])
+      }
+    })(gt_legacy_opt, gt_opt)
+  }
+  for (gt_learnr_opt in names(gradethis_default_learnr_options)) {
+    lrnr_opt <- paste0("tutorial.", gt_learnr_opt)
+    gradethis_settings[[gt_learnr_opt]] <- (function(x_opt, x_name) {
+      force(list(x_opt, x_name))
+      function() {
+        getOption(x_opt, gradethis_default_learnr_options[[x_name]])
+      }
+    })(lrnr_opt, gt_learnr_opt)
+  }
+  gradethis_settings
+})()

--- a/R/gradethis_setup.R
+++ b/R/gradethis_setup.R
@@ -210,7 +210,7 @@ gradethis_default_options <- list(
   ),
   
   # Default message and type used for a grading error
-  grading_problem.message = "A problem occurred with your teacher's grading code.",
+  grading_problem.message = "A problem occurred with the grading code for this exercise.",
   grading_problem.type = "warning",
   
   # Default value for grade_this_code(allow_partial_matching)

--- a/R/gradethis_setup.R
+++ b/R/gradethis_setup.R
@@ -73,6 +73,11 @@
 #'   `gradethis.allow_partial_matching` option.
 #' @param pipe_warning The default message used in [pipe_warning()]. Sets the
 #'   `gradethis.pipe_warning` option.
+#' @param grading_problem.message The feedback message used when a grading error occurs.
+#'   Sets the `gradethis.grading_problem.message` option.
+#' @param grading_problem.type The feedback type used when a grading error occurs.
+#'   Must be one of `"success"`, `"info"`, `"warning"` (default), `"error"`, or
+#'   `"custom"`. Sets the `gradethis.grading_problem.type` option.
 #' @param error_checker.message The default message used by gradethis's default
 #'   error checker, [gradethis_error_checker()]. Sets the 
 #'   `gradethis.error_checker.message` option.
@@ -98,6 +103,8 @@ gradethis_setup <- function(
   fail.hint = NULL,
   fail.encourage = NULL,
   pipe_warning = NULL,
+  grading_problem.message = NULL,
+  grading_problem.type = NULL,
   error_checker.message = NULL,
   allow_partial_matching = NULL,
   exercise.checker = gradethis_exercise_checker,
@@ -174,7 +181,6 @@ gradethis_setup <- function(
   invisible(old_opts)
 }
 
-
 # Default Options ---------------------------------------------------------
 
 gradethis_default_options <- list(
@@ -202,6 +208,10 @@ gradethis_default_options <- list(
     "so I want to let you know that this is how I am interpretting your code ",
     "before I check it:\n\n```r\n{.user_code_unpiped}\n```\n\n"
   ),
+  
+  # Default message and type used for a grading error
+  grading_problem.message = "A problem occurred with your teacher's grading code.",
+  grading_problem.type = "warning",
   
   # Default value for grade_this_code(allow_partial_matching)
   allow_partial_matching = NULL,

--- a/man/gradethis_setup.Rd
+++ b/man/gradethis_setup.Rd
@@ -17,6 +17,7 @@ gradethis_setup(
   fail.hint = NULL,
   fail.encourage = NULL,
   pipe_warning = NULL,
+  grading_error.message = NULL,
   error_checker.message = NULL,
   allow_partial_matching = NULL,
   exercise.checker = gradethis_exercise_checker,
@@ -102,6 +103,13 @@ partial matching is allowed in \code{grade_this_code()}. Sets the
 code when an exercise evaluation error occurs (e.g., \code{"gradethis::grade_code()"}).}
 
 \item{fail_code_feedback}{Deprecated. Use \code{maybe_code_feedback}.}
+
+\item{grading_problem.message}{The feedback message used when a grading error occurs.
+Sets the \code{gradethis.grading_problem.message} option.}
+
+\item{grading_problem.type}{The feedback type used when a grading error occurs.
+Must be one of \code{"success"}, \code{"info"}, \code{"warning"} (default), \code{"error"}, or
+\code{"custom"}. Sets the \code{gradethis.grading_problem.type} option.}
 }
 \value{
 Invisibly returns the global options as they were prior to setting
@@ -145,6 +153,8 @@ when gradethis is loaded are shown below.\tabular{ll}{
    \code{gradethis.code_correct} \tab \code{NULL} \cr
    \code{gradethis.code_incorrect} \tab \code{"{gradethis::pipe_warning()}{gradethis::code_feedback()} {gradethis::random_encouragement()}"} \cr
    \code{gradethis.pipe_warning} \tab \code{"I see that you are using pipe operators (e.g. \%>\%), so I want to let you know that this is how I am interpretting your code before I check it:\\n\\n```r\\n{.user_code_unpiped}\\n```\\n\\n"} \cr
+   \code{gradethis.grading_problem.message} \tab \code{"A problem occurred with your teacher's grading code."} \cr
+   \code{gradethis.grading_problem.type} \tab \code{"warning"} \cr
    \code{gradethis.allow_partial_matching} \tab \code{NULL} \cr
    \code{gradethis.error_checker.message} \tab \code{"An error occurred with your R code:\\n\\n```\\n{.error$message}\\n```\\n\\n\\n"} \cr
 }

--- a/man/gradethis_setup.Rd
+++ b/man/gradethis_setup.Rd
@@ -154,7 +154,7 @@ when gradethis is loaded are shown below.\tabular{ll}{
    \code{gradethis.code_correct} \tab \code{NULL} \cr
    \code{gradethis.code_incorrect} \tab \code{"{gradethis::pipe_warning()}{gradethis::code_feedback()} {gradethis::random_encouragement()}"} \cr
    \code{gradethis.pipe_warning} \tab \code{"I see that you are using pipe operators (e.g. \%>\%), so I want to let you know that this is how I am interpretting your code before I check it:\\n\\n```r\\n{.user_code_unpiped}\\n```\\n\\n"} \cr
-   \code{gradethis.grading_problem.message} \tab \code{"A problem occurred with your teacher's grading code."} \cr
+   \code{gradethis.grading_problem.message} \tab \code{"A problem occurred with the grading code for this exercise."} \cr
    \code{gradethis.grading_problem.type} \tab \code{"warning"} \cr
    \code{gradethis.allow_partial_matching} \tab \code{NULL} \cr
    \code{gradethis.error_checker.message} \tab \code{"An error occurred with your R code:\\n\\n```\\n{.error$message}\\n```\\n\\n\\n"} \cr

--- a/man/gradethis_setup.Rd
+++ b/man/gradethis_setup.Rd
@@ -17,7 +17,8 @@ gradethis_setup(
   fail.hint = NULL,
   fail.encourage = NULL,
   pipe_warning = NULL,
-  grading_error.message = NULL,
+  grading_problem.message = NULL,
+  grading_problem.type = NULL,
   error_checker.message = NULL,
   allow_partial_matching = NULL,
   exercise.checker = gradethis_exercise_checker,
@@ -85,6 +86,13 @@ encouraging phrase should be automatically appended to any \code{\link[=fail]{fa
 \item{pipe_warning}{The default message used in \code{\link[=pipe_warning]{pipe_warning()}}. Sets the
 \code{gradethis.pipe_warning} option.}
 
+\item{grading_problem.message}{The feedback message used when a grading error occurs.
+Sets the \code{gradethis.grading_problem.message} option.}
+
+\item{grading_problem.type}{The feedback type used when a grading error occurs.
+Must be one of \code{"success"}, \code{"info"}, \code{"warning"} (default), \code{"error"}, or
+\code{"custom"}. Sets the \code{gradethis.grading_problem.type} option.}
+
 \item{error_checker.message}{The default message used by gradethis's default
 error checker, \code{\link[=gradethis_error_checker]{gradethis_error_checker()}}. Sets the
 \code{gradethis.error_checker.message} option.}
@@ -103,13 +111,6 @@ partial matching is allowed in \code{grade_this_code()}. Sets the
 code when an exercise evaluation error occurs (e.g., \code{"gradethis::grade_code()"}).}
 
 \item{fail_code_feedback}{Deprecated. Use \code{maybe_code_feedback}.}
-
-\item{grading_problem.message}{The feedback message used when a grading error occurs.
-Sets the \code{gradethis.grading_problem.message} option.}
-
-\item{grading_problem.type}{The feedback type used when a grading error occurs.
-Must be one of \code{"success"}, \code{"info"}, \code{"warning"} (default), \code{"error"}, or
-\code{"custom"}. Sets the \code{gradethis.grading_problem.type} option.}
 }
 \value{
 Invisibly returns the global options as they were prior to setting

--- a/tests/testthat/helper-expect.R
+++ b/tests/testthat/helper-expect.R
@@ -234,7 +234,16 @@ expect_exercise_checker <- function(
   testthat::expect_equal(feedback$location, "append")
 
   expect_equal(feedback$correct, is_correct)
-  msg_type <- msg_type %||% (if (isTRUE(is_correct)) "success" else "error")
+  if (is.null(msg_type)) {
+    msg_type <- 
+      if (!length(is_correct)) {
+        gradethis_settings$grading_problem.type()
+      } else if (isTRUE(is_correct)) {
+        "success" 
+      } else {
+        "error"
+      }
+  }
   expect_equal(feedback$type, msg_type)
   
   msg <- message_md(msg)

--- a/tests/testthat/test-feedback.R
+++ b/tests/testthat/test-feedback.R
@@ -260,3 +260,32 @@ test_that("feedback() passes along extra information in the from graded()", {
   expect_error(feedback(grade))
 })
 
+test_that("feedback_grading_problem() picks up grading_problem options", {
+  ex <- mock_this_exercise("1 + 1")
+  
+  # internal error because solution code is missing
+  with_options(
+    list(
+      gradethis.grading_problem.message = "TEST PASS",
+      gradethis.grading_problem.type = "info"
+    ), {
+      grade <- testthat::expect_message(grade_this_code()(ex))
+      expect_equal(grade$correct, logical())
+      expect_equal(grade$message, "TEST PASS")
+      expect_equal(grade$type, "info")
+    }
+  )
+  
+  # internal error from stop() in grading code
+  with_options(
+    list(
+      gradethis.grading_problem.message = "TEST PASS",
+      gradethis.grading_problem.type = "info"
+    ), {
+      grade <- testthat::expect_message(grade_this(stop("TEST FAIL"))(ex))
+      expect_equal(grade$correct, logical())
+      expect_equal(grade$message, "TEST PASS")
+      expect_equal(grade$type, "info")
+    }
+  )
+})

--- a/tests/testthat/test-gradethis_setup.R
+++ b/tests/testthat/test-gradethis_setup.R
@@ -1,3 +1,19 @@
+test_that("gradethis_setup() sets `grading_problem.type` and `grading_problem.message`", {
+  with_options(
+    list(
+      gradethis.grading_problem.type = NULL,
+      gradethis.grading_problem.message = NULL
+    ), {
+      gradethis_setup(
+        grading_problem.type = "info", 
+        grading_problem.message = "TEST PASS"
+      )
+      expect_equal(gradethis_settings$grading_problem.type(), "info")
+      expect_equal(gradethis_settings$grading_problem.message(), "TEST PASS")
+    }
+  )
+})
+
 test_that("gradethis_setup() issues warning for invalid `grading_problem.type`", {
   with_options(list(gradethis.grading_problem.type = NULL), {
     testthat::expect_message(

--- a/tests/testthat/test-gradethis_setup.R
+++ b/tests/testthat/test-gradethis_setup.R
@@ -1,0 +1,19 @@
+test_that("gradethis_setup() issues warning for invalid `grading_problem.type`", {
+  with_options(list(gradethis.grading_problem.type = NULL), {
+    testthat::expect_message(
+      gradethis_setup(grading_problem.type = "bad"), 
+      'Defaulting to "warning"'
+    )
+    expect_equal(
+      gradethis_settings$grading_problem.type(), 
+      gradethis_default_options$grading_problem.type
+    )
+  })
+  
+  with_options(list(gradethis.grading_problem.type = "PASS"), {
+    testthat::expect_message(
+      gradethis_setup(grading_problem.type = "bad"), 
+      'Defaulting to "warning"'
+    )
+  })
+})

--- a/tests/testthat/test_grade_this_learnr.R
+++ b/tests/testthat/test_grade_this_learnr.R
@@ -105,7 +105,7 @@ test_that("length 0 solution code", {
 test_that("pass / fail in check chunk are caught", {
   err <- testthat::expect_message(
     expect_exercise_checker(
-      is_correct = FALSE,
+      is_correct = logical(),
       msg = message_feedback_grading_problem,
       user_code = "1",
       solution_code = "1",
@@ -119,7 +119,7 @@ test_that("pass / fail in check chunk are caught", {
   
   err <- testthat::expect_message(
     expect_exercise_checker(
-      is_correct = FALSE,
+      is_correct = logical(),
       msg = message_feedback_grading_problem,
       user_code = "1",
       solution_code = "1",
@@ -135,7 +135,7 @@ test_that("pass / fail in check chunk are caught", {
 test_that("check parsing error is caught", {
   err <- testthat::expect_message(
     expect_exercise_checker(
-      is_correct = FALSE,
+      is_correct = logical(),
       msg = message_feedback_grading_problem,
       user_code = "1",
       solution_code = "1",
@@ -152,7 +152,7 @@ test_that("check parsing error is caught", {
 test_that("return value is a function of 1 argument", {
   err <- testthat::expect_message(
     expect_exercise_checker(
-      is_correct = FALSE,
+      is_correct = logical(),
       msg = message_feedback_grading_problem,
       user_code = "1",
       solution_code = "1",
@@ -167,7 +167,7 @@ test_that("return value is a function of 1 argument", {
   
   err <- testthat::expect_message(
     expect_exercise_checker(
-      is_correct = FALSE,
+      is_correct = logical(),
       msg = message_feedback_grading_problem,
       user_code = "1",
       solution_code = "1",
@@ -191,7 +191,7 @@ test_that("return value is a function of 1 argument", {
 test_that("a grade is given", {
   err <- testthat::expect_message(
     expect_exercise_checker(
-      is_correct = FALSE,
+      is_correct = logical(),
       msg = message_feedback_grading_problem,
       user_code = "1",
       solution_code = "1",


### PR DESCRIPTION
- Add `grading_problem.{message,type}` to `gradethis_setup()`
- Add internal helper for getting gradthis settings
- Use settings getter helper functions in grading problem functions
