### PR TITLE
Add `stage` argument to exercise checker

### DIFF
--- a/R/gradethis_exercise_checker.R
+++ b/R/gradethis_exercise_checker.R
@@ -155,7 +155,8 @@ check_exercise <- function(
     }
   )
 
-  if (is.null(stage)) {
+  # Skip parse checking if it was already done in {learnr}
+  if (!learnr_includes_parse_check()) {
     tryCatch(
       parse(text = user_code %||% ""),
       error = function(e) {
@@ -310,4 +311,8 @@ grade_parse_error <- function(check_obj) {
       )
     }
   fail(message = msg, error = list(message = check_obj$.error$message, call = check_obj$.user_code))
+}
+
+learnr_includes_parse_check <- function(stage) {
+  !is.null(stage) && rlang::is_installed("learnr", version = "0.10.1.9017")
 }

--- a/R/gradethis_exercise_checker.R
+++ b/R/gradethis_exercise_checker.R
@@ -26,6 +26,7 @@
 #'   chunk.
 #' @param last_value The last value from evaluating the user's exercise
 #'   submission.
+#' @param stage The current stage of exercise checking.
 #' @param ... Extra arguments supplied by learnr
 #'
 #' @return Returns a feedback object suitable for \pkg{learnr} tutorials with
@@ -43,6 +44,7 @@ gradethis_exercise_checker <- function(
   evaluate_result = NULL,
   envir_prep = NULL,
   last_value = NULL,
+  stage = NULL,
   ...
 ) {
   # Call this function in such a way that it can use other gradethis internals when called by learnr
@@ -56,6 +58,7 @@ gradethis_exercise_checker <- function(
     evaluate_result = evaluate_result,
     envir_prep = envir_prep,
     last_value = last_value,
+    stage = stage,
     ...
   )
 }
@@ -69,6 +72,7 @@ check_exercise <- function(
   evaluate_result = NULL,
   envir_prep = NULL,
   last_value = NULL,
+  stage = NULL,
   ...
 ) {
 
@@ -81,6 +85,7 @@ check_exercise <- function(
     evaluate_result = evaluate_result,
     envir_prep = envir_prep,
     last_value = last_value,
+    stage = stage,
     ...
   )
 

--- a/R/gradethis_exercise_checker.R
+++ b/R/gradethis_exercise_checker.R
@@ -155,15 +155,17 @@ check_exercise <- function(
     }
   )
 
-  tryCatch(
-    parse(text = user_code %||% ""),
-    error = function(e) {
-      # Add the error object to the checking object
-      check_env$.error <- e
-      # Overwrite `to_check_fn` to validate the parse error function accepts `check_obj_envir`
-      to_check_fn <<- getOption("exercise.parse.error", grade_parse_error)
-    }
-  )
+  if (is.null(stage)) {
+    tryCatch(
+      parse(text = user_code %||% ""),
+      error = function(e) {
+        # Add the error object to the checking object
+        check_env$.error <- e
+        # Overwrite `to_check_fn` to validate the parse error function accepts `check_obj_envir`
+        to_check_fn <<- getOption("exercise.parse.error", grade_parse_error)
+      }
+    )
+  }
 
   if (
     !(

--- a/R/gradethis_exercise_checker.R
+++ b/R/gradethis_exercise_checker.R
@@ -156,7 +156,7 @@ check_exercise <- function(
   )
 
   # Skip parse checking if it was already done in {learnr}
-  if (!learnr_includes_parse_check()) {
+  if (!learnr_includes_parse_check(stage)) {
     tryCatch(
       parse(text = user_code %||% ""),
       error = function(e) {

--- a/man/gradethis_exercise_checker.Rd
+++ b/man/gradethis_exercise_checker.Rd
@@ -13,6 +13,7 @@ gradethis_exercise_checker(
   evaluate_result = NULL,
   envir_prep = NULL,
   last_value = NULL,
+  stage = NULL,
   ...
 )
 }
@@ -37,6 +38,8 @@ chunk.}
 
 \item{last_value}{The last value from evaluating the user's exercise
 submission.}
+
+\item{stage}{The current stage of exercise checking.}
 
 \item{...}{Extra arguments supplied by learnr}
 }


### PR DESCRIPTION
Adds a `stage` argument to `gradethis_exercise_checker()` and `check_exercise()` to take advantage of rstudio/learnr#610.

If `stage` is set, `gradethis` skips parse checking, since parse checking will have already occurred in `learnr`.