### PR TITLE
Fix mocked `check_env` environment tree

### DIFF
--- a/R/mock.R
+++ b/R/mock.R
@@ -113,19 +113,23 @@ mock_this_exercise <- function(
     .result <- .error
   }
 
-  check_env <- list2env(list(
-    .result = .result,
-    .last_value = .result,
-    .user = .result,
-    .user_code = expr_text(.user_code),
-    .solution_code = expr_text(.solution_code),
-    .label = .label,
-    .stage = .stage,
-    .engine = .engine,
-    .error = .error,
-    .envir_prep = env_prep,
-    .envir_result = env_result
-  ))
+  env_base <- learnr::duplicate_env(env_prep)
+  check_env <- rlang::new_environment(
+    parent = env_base,
+    data = list(
+      .result = .result,
+      .last_value = .result,
+      .user = .result,
+      .user_code = expr_text(.user_code),
+      .solution_code = expr_text(.solution_code),
+      .label = .label,
+      .stage = .stage,
+      .engine = .engine,
+      .error = .error,
+      .envir_prep = env_prep,
+      .envir_result = env_result
+    )
+  )
 
   delayedAssign(
     assign.env = check_env,
@@ -142,8 +146,7 @@ mock_this_exercise <- function(
         )
       } else {
         # solution code exists...
-        # Using eval_tidy does not evaluate the expression. Using eval() instead
-        eval_code(.solution_code, rlang::env_clone(env_prep, env_global))
+        eval_code(.solution_code, env_base)
       }
     }
   )

--- a/tests/testthat/test-mock.R
+++ b/tests/testthat/test-mock.R
@@ -101,12 +101,12 @@ test_that("mock_this_exercise() evaluates solution into check_env parent", {
     "x <- 12",
     "y <- 30"
   )
-  
+
   force(ex$.solution)
-  
+
   expect_false(exists("x", ex))
   expect_true(exists("x", ex$.envir_result))
-  
+
   expect_true(exists("y", ex))
   expect_false(exists("y", ex, inherits = FALSE))
   expect_true(exists("y", parent.env(ex), inherits = FALSE))

--- a/tests/testthat/test-mock.R
+++ b/tests/testthat/test-mock.R
@@ -95,3 +95,20 @@ test_that("user error populates .error, .result, .last_value, .user", {
   expect_condition_message(ex$.last_value, "boom")
   expect_condition_message(ex$.user, "boom")
 })
+
+test_that("mock_this_exercise() evaluates solution into check_env parent", {
+  ex <- mock_this_exercise(
+    "x <- 12",
+    "y <- 30"
+  )
+  
+  force(ex$.solution)
+  
+  expect_false(exists("x", ex))
+  expect_true(exists("x", ex$.envir_result))
+  
+  expect_true(exists("y", ex))
+  expect_false(exists("y", ex, inherits = FALSE))
+  expect_true(exists("y", parent.env(ex), inherits = FALSE))
+  expect_equal(get("y", ex), 30)
+})


### PR DESCRIPTION
The environment tree of a mocked exercise checking environment now more closely resembles the environment chain produced by `gradethis_exercise_checker()`.

In the future we might want to revisit `mock_this_exercise()` and refactor it to use `preapre_check_env()` directly, but since `mock_this_exercise()` has to do some of the work we expect to be handled by learnr, it might not be worth it.

Fixes #270