### PR TITLE
Allow `grade_this_code()` to provide pass-through-filter grading

### DIFF
--- a/R/grade_this_code.R
+++ b/R/grade_this_code.R
@@ -17,16 +17,26 @@
 #' ```
 #' ````
 #'
-#' Then, call `grade_this_code()` in your exercise's `-check` chunk:
+#' Then, call `grade_this_code()` in your exercise's `-check` or `-code-check` chunk:
 #'
 #' ````
 #' ```{r example-check}
 #' grade_this_code()
 #' ```
 #' ````
+#' 
+#' If `grade_this_code()` is called in a `-code-check` chunk and returns
+#' feedback, either passing or failing feedback, then the user's code is not
+#' executed. If you want the user to see the output of their code, call
+#' `grade_this_code()` in the `-check` chunk. You can also use
+#' `grade_this_code()` as a pre-check to avoid running code when it fails or
+#' passes by calling `grade_this_code()` inside the `-code-check` chunk and
+#' setting `action = "pass"` or `action = "fail"` to only return feedback when
+#' the user's code passes or fails, respectively. (Note: requires \pkg{learnr}
+#' version 0.10.1.9017 or later.)
 #'
 #' Learn more about how to use `grade_this_code()` in the **Details** section
-#'
+#' below.
 #'
 #' @section Details:
 #'
@@ -121,6 +131,7 @@
 #'     .solution_code = "storms %>% select(year, month, day)"
 #'   )
 #' )
+#'
 #' @param correct A `glue`-able character string to display if the student
 #'   answer matches a known correct answer.
 #' @param incorrect A `glue`-able character string to display if the student

--- a/R/gradethis_exercise_checker.R
+++ b/R/gradethis_exercise_checker.R
@@ -197,8 +197,8 @@ check_exercise <- function(
 
   # make sure the result is a pass or fail
   if (!is_graded(graded_result)) {
-    if (!is.null(stage) && stage %in% c("code_check", "error_check")) {
-      # It's okay for these stages to not return feedback
+    if (!is.null(stage) && !identical(tolower(stage), "check")) {
+      # check chunks require a final answer, others might defer to later stages
       return()
     }
     

--- a/R/gradethis_exercise_checker.R
+++ b/R/gradethis_exercise_checker.R
@@ -197,6 +197,11 @@ check_exercise <- function(
 
   # make sure the result is a pass or fail
   if (!is_graded(graded_result)) {
+    if (!is.null(stage) && stage %in% c("code_check", "error_check")) {
+      # It's okay for these stages to not return feedback
+      return()
+    }
+    
     err_result_not_graded <- list(
       message = paste0(
         "`", check_label, "` chunk did not mark an answer as correct or incorrect.",

--- a/man/grade_this_code.Rd
+++ b/man/grade_this_code.Rd
@@ -61,12 +61,23 @@ sqrt(log(1))
 ```
 }
 
-Then, call \code{grade_this_code()} in your exercise's \code{-check} chunk:\preformatted{```\{r example-check\}
+Then, call \code{grade_this_code()} in your exercise's \code{-check} or \code{-code-check} chunk:\preformatted{```\{r example-check\}
 grade_this_code()
 ```
 }
 
+If \code{grade_this_code()} is called in a \code{-code-check} chunk and returns
+feedback, either passing or failing feedback, then the user's code is not
+executed. If you want the user to see the output of their code, call
+\code{grade_this_code()} in the \code{-check} chunk. You can also use
+\code{grade_this_code()} as a pre-check to avoid running code when it fails or
+passes by calling \code{grade_this_code()} inside the \code{-code-check} chunk and
+setting \code{action = "pass"} or \code{action = "fail"} to only return feedback when
+the user's code passes or fails, respectively. (Note: requires \pkg{learnr}
+version 0.10.1.9017 or later.)
+
 Learn more about how to use \code{grade_this_code()} in the \strong{Details} section
+below.
 }
 \section{Details}{
 
@@ -164,6 +175,7 @@ grade_this_code(
     .solution_code = "storms \%>\% select(year, month, day)"
   )
 )
+
 }
 \seealso{
 \code{\link[=code_feedback]{code_feedback()}}, \code{\link[=grade_this]{grade_this()}}, \code{\link[=mock_this_exercise]{mock_this_exercise()}}

--- a/man/grade_this_code.Rd
+++ b/man/grade_this_code.Rd
@@ -10,7 +10,8 @@ grade_this_code(
   incorrect = getOption("gradethis.code_incorrect", getOption("gradethis.fail",
     "Incorrect")),
   ...,
-  allow_partial_matching = getOption("gradethis.allow_partial_matching", TRUE)
+  allow_partial_matching = getOption("gradethis.allow_partial_matching", TRUE),
+  action = c("both", "pass", "fail")
 )
 }
 \arguments{
@@ -29,6 +30,15 @@ argument names is not allowed and e.g. \code{runif(1, mi = 0)} will return a
 message indicating that the full formal name \code{min} should be used. The
 default is set via the \code{gradethis.allow_partial_matching} option, or by
 \code{\link[=gradethis_setup]{gradethis_setup()}}.}
+
+\item{action}{The action to take:
+\enumerate{
+\item \code{"pass"} provide passing \code{correct} feedback when the user's code
+matches the solution code.
+\item \code{"fail"} provide failing \code{incorrect} feedback when the user's code does
+not match the solution code.
+\item \code{"both"} always provide passing or failing feedback.
+}}
 }
 \value{
 Returns a function whose first parameter will be an environment

--- a/tests/testthat/helper-expect.R
+++ b/tests/testthat/helper-expect.R
@@ -204,7 +204,9 @@ expect_exercise_checker <- function(
   msg,
   msg_type = NULL,
   msg_fixed = TRUE,
-  error_message = NULL
+  error_message = NULL,
+  stage = NULL,
+  expect_feedback = TRUE
 ) {
   envir_prep <- new.env(parent = .GlobalEnv)
   eval(parse(text = prep_code), envir = envir_prep)
@@ -223,8 +225,13 @@ expect_exercise_checker <- function(
     envir_result = envir_result,
     evaluate_result = "ignore",
     envir_prep = envir_prep,
-    last_value = last_value
+    last_value = last_value,
+    stage = stage
   )
+  
+  if (!expect_feedback) {
+    return(feedback)
+  }
 
   checkmate::expect_names(names(feedback), must.include = c("message", "correct", "type", "location"))
   checkmate::expect_string(feedback$message, null.ok = TRUE)

--- a/tests/testthat/test-grade_this_code.R
+++ b/tests/testthat/test-grade_this_code.R
@@ -168,3 +168,17 @@ test_that("Spots differences in long calls", {
   expect_this_code(user, solution, is_correct = TRUE)
 
 })
+
+test_that("grade_this_code() doesn't have to return a grade", {
+  # user code is incorrect
+  ex_fails <- mock_this_exercise("1", "2")
+  expect_graded(grade_this_code(action = "both")(ex_fails), is_correct = FALSE)
+  expect_graded(grade_this_code(action = "fail")(ex_fails), is_correct = FALSE)
+  expect_null(grade_this_code(action = "pass")(ex_fails))
+  
+  # user code is correct
+  ex_ok <- mock_this_exercise("1 + 1", "1 + 1")
+  expect_graded(grade_this_code(action = "both")(ex_ok), is_correct = TRUE)
+  expect_graded(grade_this_code(action = "pass")(ex_ok), is_correct = TRUE)
+  expect_null(grade_this_code(action = "fail")(ex_ok))
+})

--- a/tests/testthat/test-grade_this_code.R
+++ b/tests/testthat/test-grade_this_code.R
@@ -1,5 +1,3 @@
-context("Check Code")
-
 # these tests are largely redundant exercises that have been tested against detect_mistakes()
 
 test_that("Spots differences in atomics", {

--- a/tests/testthat/test-gradethis_exercise_checker.R
+++ b/tests/testthat/test-gradethis_exercise_checker.R
@@ -1,5 +1,3 @@
-context("Check grade learnr")
-
 test_that("prep environment is used", {
   expect_exercise_checker(
     is_correct = TRUE,
@@ -12,7 +10,8 @@ test_that("prep environment is used", {
       grade_this({
         pass_if_equal(4, 'yes. you did it. {extra}')
       })
-    "
+    ",
+    stage = "check"
   )
 })
 
@@ -26,7 +25,8 @@ test_that("check environment is used", {
       grade_this({
         pass_if_equal(4, 'yes. you did it. {extra}')
       })
-    "
+    ",
+    stage = "check"
   )
 })
 
@@ -60,7 +60,8 @@ test_that("user and solution code are always length 1", {
     is_correct = TRUE,
     msg = "TEST PASSED",
     user_code = c("1", "2", "3"),
-    check_code = "grade_this(if (length(.user_code) == 1) pass('TEST PASSED') else fail('TEST FAILED'))"
+    check_code = "grade_this(if (length(.user_code) == 1) pass('TEST PASSED') else fail('TEST FAILED'))",
+    stage = "check"
   )
 
   expect_exercise_checker(
@@ -68,7 +69,8 @@ test_that("user and solution code are always length 1", {
     msg = "TEST PASSED",
     user_code = c("1", "2", "3"),
     solution_code= c("1", "2", "3", "4"),
-    check_code = "grade_this(if (length(.solution_code) == 1) pass('TEST PASSED') else fail('TEST FAILED'))"
+    check_code = "grade_this(if (length(.solution_code) == 1) pass('TEST PASSED') else fail('TEST FAILED'))",
+    stage = "check"
   )
 
   expect_exercise_checker(
@@ -83,7 +85,8 @@ test_that("user and solution code are always length 1", {
       "else",
       "fail('TEST FAILED')",
       ")"
-    )
+    ),
+    stage = "check"
   )
 })
 
@@ -97,7 +100,8 @@ test_that("length 0 solution code", {
     msg_type = "info",
     user_code = "1",
     check_code = "grade_this({pass(.solution)})",
-    solution_code = ""
+    solution_code = "",
+    stage = "check"
   )
 })
 
@@ -110,7 +114,8 @@ test_that("pass / fail in check chunk are caught", {
       user_code = "1",
       solution_code = "1",
       check_code = "pass()",
-      error_message = "prematurely graded"
+      error_message = "prematurely graded",
+      stage = "check"
     ),
     "prematurely graded"
   )
@@ -124,7 +129,8 @@ test_that("pass / fail in check chunk are caught", {
       user_code = "1",
       solution_code = "1",
       check_code = "fail()",
-      error_message = "prematurely graded"
+      error_message = "prematurely graded",
+      stage = "check"
     ),
     "prematurely graded"
   )
@@ -140,7 +146,8 @@ test_that("check parsing error is caught", {
       user_code = "1",
       solution_code = "1",
       check_code = "4 +",
-      error_message = "unexpected end of input"
+      error_message = "unexpected end of input",
+      stage = NULL
     ),
     "Error while checking `test-check` chunk: "
   )
@@ -157,7 +164,8 @@ test_that("return value is a function of 1 argument", {
       user_code = "1",
       solution_code = "1",
       check_code = "1",
-      error_message = "chunk did not return a function"
+      error_message = "chunk did not return a function",
+      stage = "check"
     ),
     "chunk did not return a function (such as `grade_this`) that accepts 1 argument", fixed = TRUE
   )
@@ -172,7 +180,8 @@ test_that("return value is a function of 1 argument", {
       user_code = "1",
       solution_code = "1",
       check_code = "Sys.time",
-      error_message = "chunk did not return a function"
+      error_message = "chunk did not return a function",
+      stage = "check"
     ),
     "chunk did not return a function (such as `grade_this`) that accepts 1 argument", fixed = TRUE
   )
@@ -184,7 +193,8 @@ test_that("return value is a function of 1 argument", {
     msg = "test pass",
     user_code = "1",
     solution_code = "1",
-    check_code = "function(...) pass('test pass')"
+    check_code = "function(...) pass('test pass')",
+    stage = "check"
   )
 })
 
@@ -196,33 +206,47 @@ test_that("a grade is given", {
       user_code = "1",
       solution_code = "1",
       check_code = "function(...) NULL",
-      error_message = "chunk did not mark an answer as correct or incorrect"
+      error_message = "chunk did not mark an answer as correct or incorrect",
+      stage = "check"
     ),
     "chunk did not mark an answer as correct or incorrect", fixed = TRUE
   )
   expect_equal(err$error$call, "1")
   expect_equal(err$error$label, "test-check")
+  
+  expect_null(
+    expect_exercise_checker(
+      user_code = "1",
+      solution_code = "1",
+      check_code = "grade_this({ fail_if_code_feedback() })",
+      stage = "code_check",
+      expect_feedback = FALSE
+    )
+  )
 
   expect_exercise_checker(
     is_correct = TRUE,
     msg = "test pass",
     user_code = "1",
     solution_code = "1",
-    check_code = "function(...) pass('test pass')"
+    check_code = "function(...) pass('test pass')",
+    stage = "check"
   )
   expect_exercise_checker(
     is_correct = FALSE,
     msg = "test fail",
     user_code = "1",
     solution_code = "1",
-    check_code = "function(...) fail('test fail')"
+    check_code = "function(...) fail('test fail')",
+    stage = "check"
   )
   expect_exercise_checker(
     is_correct = FALSE,
     msg = "boom",
     user_code = "1",
     solution_code = "1",
-    check_code = "function(...) fail_if_error(stop('boom'))"
+    check_code = "function(...) fail_if_error(stop('boom'))",
+    stage = "check"
   )
 })
 


### PR DESCRIPTION
This PR relaxes the constraint applied in `gradethis_exercise_checker()` that gradethis grading functions must return either passing or failing feedback. This builds on rstudio/learnr#610 and uses the new `stage` argument set in the checker function when evaluating exercises. The constraint is now only applied to `stage == "check"` since this defines the terminal check action and other grading chunks might pass through.

Then, we build on the above feature by adding an `action` parameter to `grade_this_code()`, allowing the grading author to choose if `grade_this_code()` will _pass_ or _fail_ the user's code. The default is `"both"` to be consistent with current behavior. If either `"pass"` or `"fail"` are chosen, feedback that would result in the opposite action is ignored and no feedback is returned.

The end result is that authors can write check chunks that use static code analysis to filter out problematic results that might be computationally intensive, but that defer to the `-check` chunk when the code matches.

````markdown
Use the correct join function to correctly combine these two giant tables without crashing your session.

```{r join, exercise = TRUE}
dplyr::____(giant, huge)
```

```{r join-solution}
dplyr::inner_join(giant, huge)
```

```{r join-code-check}
grade_this_code(incorrect = "Not that one", action = "fail")
```

```{r join-check}
grade_this({
  pass_if_equal(message = "Good choice!")
  fail()
})
```
````

If the user picks `left_join()`, static analysis will return a feedback message highlighting the user's mistake. If the user picks `inner_join()`, `grade_this_code()` defers to the `-check` chunk where the user's evaluated code is graded. (Totally made up example, but similar issues arise in plotting and many other places.)