### PR TITLE
Fix setting learnr knitr chunk options in gradethis_setup()

### DIFF
--- a/R/gradethis_setup.R
+++ b/R/gradethis_setup.R
@@ -144,10 +144,7 @@ gradethis_setup <- function(
       do.call(learnr::tutorial_options, set_opts[learnr_opt])
     } else if (is.null(knitr::opts_chunk$get(learnr_opt)) || learnr_opt == "exercise.checker") {
       # Ensure that the default value is set
-      knitr::opts_chunk$set(
-        learnr_opt,
-        gradethis_default_learnr_options[[learnr_opt]]
-      )
+      knitr::opts_chunk$set(gradethis_default_learnr_options[learnr_opt])
     }
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -70,3 +70,24 @@ local_options_waldo_compare <- function(.local_envir = parent.frame()) {
 
   withr::local_options(waldo_opts, .local_envir = .local_envir)
 }
+
+local_knitr_opts_chunk <- function (new = list(), .local_envir = parent.frame()) {
+  old <- knitr::opts_chunk$get()
+  knitr::opts_chunk$set(new)
+  
+  withr::defer(envir = .local_envir, {
+    knitr::opts_chunk$set(old)
+    new_opts <- setdiff(names(new), names(old))
+    for (opt in new_opts) {
+      # restore opts that were created in `new`
+      knitr::opts_chunk$restore(opt)
+    }
+  })
+  
+  invisible(old)
+}
+
+with_knitr_opts_chunk <- function(new, expr) {
+  local_knitr_opts_chunk(new)
+  force(expr)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -74,7 +74,7 @@ local_options_waldo_compare <- function(.local_envir = parent.frame()) {
 local_knitr_opts_chunk <- function (new = list(), .local_envir = parent.frame()) {
   old <- knitr::opts_chunk$get()
   knitr::opts_chunk$set(new)
-  
+
   withr::defer(envir = .local_envir, {
     knitr::opts_chunk$set(old)
     new_opts <- setdiff(names(new), names(old))
@@ -83,7 +83,7 @@ local_knitr_opts_chunk <- function (new = list(), .local_envir = parent.frame())
       knitr::opts_chunk$restore(opt)
     }
   })
-  
+
   invisible(old)
 }
 

--- a/gradethis.Rproj
+++ b/gradethis.Rproj
@@ -16,5 +16,6 @@ AutoAppendNewline: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
+PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace,vignette

--- a/tests/testthat/test-gradethis_setup.R
+++ b/tests/testthat/test-gradethis_setup.R
@@ -38,19 +38,13 @@ test_that("gradethis_setup() sets default learnr options via chunk opts", {
   local_knitr_opts_chunk()
 
   with_knitr_opts_chunk(list(exercise.checker = "fail"), {
-    gradethis_setup()
-    expect_identical(
-      knitr::opts_chunk$get("exercise.checker"),
-      gradethis_exercise_checker
-    )
+    gradethis_setup(exercise.checker = "PASS")
+    expect_equal(knitr::opts_chunk$get("exercise.checker"), "PASS")
   })
 
   with_knitr_opts_chunk(list(exercise.checker = "fail"), {
-    gradethis_setup(exercise.timelimit = 42)
-    expect_identical(
-      knitr::opts_chunk$get("exercise.checker"),
-      gradethis_exercise_checker
-    )
+    gradethis_setup(exercise.checker = "PASS", exercise.timelimit = 42)
+    expect_equal(knitr::opts_chunk$get("exercise.checker"), "PASS")
     expect_equal(knitr::opts_chunk$get("exercise.timelimit"), 42)
   })
 })

--- a/tests/testthat/test-gradethis_setup.R
+++ b/tests/testthat/test-gradethis_setup.R
@@ -33,3 +33,24 @@ test_that("gradethis_setup() issues warning for invalid `grading_problem.type`",
     )
   })
 })
+
+test_that("gradethis_setup() sets default learnr options via chunk opts", {
+  local_knitr_opts_chunk()
+  
+  with_knitr_opts_chunk(list(exercise.checker = "fail"), {
+    gradethis_setup()
+    expect_equal(
+      knitr::opts_chunk$get("exercise.checker"), 
+      gradethis_exercise_checker
+    )
+  })
+  
+  with_knitr_opts_chunk(list(exercise.checker = "fail"), {
+    gradethis_setup(exercise.timelimit = 42)
+    expect_equal(
+      knitr::opts_chunk$get("exercise.checker"), 
+      gradethis_exercise_checker
+    )
+    expect_equal(knitr::opts_chunk$get("exercise.timelimit"), 42)
+  })
+})

--- a/tests/testthat/test-gradethis_setup.R
+++ b/tests/testthat/test-gradethis_setup.R
@@ -39,7 +39,7 @@ test_that("gradethis_setup() sets default learnr options via chunk opts", {
 
   with_knitr_opts_chunk(list(exercise.checker = "fail"), {
     gradethis_setup()
-    expect_equal(
+    expect_identical(
       knitr::opts_chunk$get("exercise.checker"),
       gradethis_exercise_checker
     )
@@ -47,7 +47,7 @@ test_that("gradethis_setup() sets default learnr options via chunk opts", {
 
   with_knitr_opts_chunk(list(exercise.checker = "fail"), {
     gradethis_setup(exercise.timelimit = 42)
-    expect_equal(
+    expect_identical(
       knitr::opts_chunk$get("exercise.checker"),
       gradethis_exercise_checker
     )

--- a/tests/testthat/test-gradethis_setup.R
+++ b/tests/testthat/test-gradethis_setup.R
@@ -36,19 +36,19 @@ test_that("gradethis_setup() issues warning for invalid `grading_problem.type`",
 
 test_that("gradethis_setup() sets default learnr options via chunk opts", {
   local_knitr_opts_chunk()
-  
+
   with_knitr_opts_chunk(list(exercise.checker = "fail"), {
     gradethis_setup()
     expect_equal(
-      knitr::opts_chunk$get("exercise.checker"), 
+      knitr::opts_chunk$get("exercise.checker"),
       gradethis_exercise_checker
     )
   })
-  
+
   with_knitr_opts_chunk(list(exercise.checker = "fail"), {
     gradethis_setup(exercise.timelimit = 42)
     expect_equal(
-      knitr::opts_chunk$get("exercise.checker"), 
+      knitr::opts_chunk$get("exercise.checker"),
       gradethis_exercise_checker
     )
     expect_equal(knitr::opts_chunk$get("exercise.timelimit"), 42)


### PR DESCRIPTION
There was a minor typo in `gradethis_setup()` that caused it not to set `exercise.checker` on every run. Typically, this value is actually set earlier via `.onLoad()` and `gradethis_setup()` is just a fallback method. But in the unusual case where `rmarkdown::run()` is used to run the tutorial twice in a row from a clean R session, then there was a chance that `gradethis_setup()` would be required and would fail to set the checker option. This wasn't obviously apparent until learnr started throwing an error when encountering a `-check` chunk without an `exercise.checker`.

If the tutorial setup code includes only

```r
library(learnr)
library(gradethis)
```

and the tutorial is run twice from a clean R session

```r
rmarkdown::run("tutorial.Rmd")
#> ... first run works perfectly, but rmarkdown::run() clears knitr options

rmarkdown::run("tutorial.Rmd")
#> Error ... An exercise check chunk exists ('....-check') but an exercise 
#>   checker function is not configured for this tutorial. Please use 
#>   `tutorial_options()` to define an `exercise.checker`.
```

Then you can run `gradethis_setup()` from the console to make sure the checker is set in the global environment. Alternatively, users could load `learnr` and `gradethis` globally before running the tutorial.

```r
gradethis::gradethis_setup()
rmarkdown::run("tutorial.Rmd")

# or restart the R session and...

library(learnr)
library(gradethis)
rmarkdown::run("tutorial.Rmd")
```

Note that these issues only arise when using the command line. Using the "Run Document" button, the tutorials pane, or `learnr::run_tutorial()` with `as_rstudio_job = TRUE` (the default) will not encounter this problem.

To make testing easier, I added `local_knitr_opts_chunk()` and `with_knitr_opts_chunk()`, both of which are likely to be helpful elsewhere.

