### PR TITLE
Wrap grading logic in a function to enable `return()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 * Added `gradethis_error_checker()`, a more robust checking function for general use when the student's submission _should not_ throw an error. (#234)
 * `grade_this_code()` gains an `action` argument, allowing authors to choose if `grade_this_code()` should only `"pass"` or `"fail"` the user's submission. By default, `grade_this_code()` uses `action = "both"` to maintain current behavior. (#276)
 * When combined with learnr version 0.10.1.9017 or later, gradethis' exercise checking function will not require that grading code absolutely return feedback unless exercise checking is at the `"check"` stage. (#276)
+* You may now call `return()` in `grade_this()` grading code to exit grading early. This is allowed in code and error checking code, but will result in an "internal error" when used in the `-check` chunk grading code (#284).
 
 ### Breaking changes
 

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -143,10 +143,10 @@ grade_this <- function(
     }
 
     check_env[[".__gradethis_check_env"]] <- TRUE
-    
+
     # Make check env a child of the original env where grade_this() was called
     rlang::env_poke_parent(check_env, expr_env)
-    
+
     # Turn the grading code into a function defined in the `check_env`
     do_grade_this <- rlang::new_function(NULL, body = expr, env = check_env)
 

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -122,7 +122,9 @@ grade_this <- function(
   ...,
   maybe_code_feedback = getOption("gradethis.maybe_code_feedback", TRUE)
 ) {
-  express <- rlang::get_expr(rlang::enquo(expr))
+  expr_quo <- rlang::enquo(expr)
+  expr_env <- rlang::quo_get_env(expr_quo)
+  expr <- rlang::quo_get_expr(expr_quo)
 
   if ("fail_code_feedback" %in% names(list(...))) {
     lifecycle::deprecate_warn(
@@ -141,20 +143,19 @@ grade_this <- function(
     }
 
     check_env[[".__gradethis_check_env"]] <- TRUE
+    
+    # Make check env a child of the original env where grade_this() was called
+    rlang::env_poke_parent(check_env, expr_env)
+    
+    # Turn the grading code into a function defined in the `check_env`
+    do_grade_this <- rlang::new_function(NULL, body = expr, env = check_env)
 
     # make sure fail calls can get code feed back (or not) if they want
     with_maybe_code_feedback(
       maybe_code_feedback,
 
       # capture all pass/fail calls and errors thrown
-      eval_gradethis({
-
-        # force the evaluation of the expression in an environment
-        rlang::eval_bare(
-          express,
-          env = check_env
-        )
-      })
+      eval_gradethis(do_grade_this())
     )
   }
 }

--- a/tests/testthat/test-grade_this.R
+++ b/tests/testthat/test-grade_this.R
@@ -1,0 +1,19 @@
+test_that("grade_this() can find objects in the original env where it was defined", {
+  from_calling_env <- "CALLER"
+  grader <- grade_this({
+    return(from_calling_env)
+  })
+  
+  expect_equal(
+    grader(mock_this_exercise(1)),
+    "CALLER"
+  )
+})
+
+test_that("grade_this() can return early", {
+  expect_null(
+    grade_this({
+      return()
+    })(mock_this_exercise(1))
+  )
+})

--- a/tests/testthat/test-grade_this.R
+++ b/tests/testthat/test-grade_this.R
@@ -3,7 +3,7 @@ test_that("grade_this() can find objects in the original env where it was define
   grader <- grade_this({
     return(from_calling_env)
   })
-  
+
   expect_equal(
     grader(mock_this_exercise(1)),
     "CALLER"


### PR DESCRIPTION
This PR makes a subtle change in how the grading code is evaluated. Instead of evaluating the grading code in `grade_this()` as an expression, we instead create a function defined in the checking environment and call that function. This allows us to enable the use of `return()` inside the grading code as a method for exiting early.

``` r
pkgload::load_all()
#> ℹ Loading gradethis

A_CONSTANT <- "this is fine"

grader <- grade_this({
  if (.result == 1) {
    fail(A_CONSTANT)
  } else if (.result == 2) {
    # do nothing
    return()
  }
  pass("hooray!")
})

grader(mock_this_exercise(2))
#> NULL
grader(mock_this_exercise(3))
#> <gradethis_graded: [Correct] hooray!>
```

Because we were previously capturing the grading code as a quosure, we now explicitly attach the `check_env` as a child of the environment where `grade_this()` was called.

```r
grader(mock_this_exercise(1))
#> <gradethis_graded: [Incorrect] this is fine>
A_CONSTANT <- "I mean, what could go wrong?"
grader(mock_this_exercise(1))
#> <gradethis_graded: [Incorrect] I mean, what could go wrong?>
```

Previous behavior was the same, other than an error when calling `return()` in grading code.

```r
# main: 6324f69f
grader(mock_this_exercise(1))
#> <gradethis_graded: [Incorrect] this is fine>
A_CONSTANT <- "I mean, what could go wrong?"
grader(mock_this_exercise(1))
#> <gradethis_graded: [Incorrect] I mean, what could go wrong?>
grader(mock_this_exercise(2))
#> #> grader(mock_this_exercise(2))
#> Error in rlang::eval_bare(express, env = check_env): no function to return from, jumping to top level
#> <gradethis_graded: [Neutral]
#>   A problem occurred with the grading code for this exercise.
#> >
grader(mock_this_exercise(3))
#> <gradethis_graded: [Correct] hooray!>
```