### PR TITLE
Don't duplicate extras (praise, encouragement, etc.)

### DIFF
--- a/R/graded.R
+++ b/R/graded.R
@@ -520,7 +520,7 @@ pass_if <- function(
     assert_gradethis_condition_type_is_value(cond, "pass_if")
     if (cond) {
       message <- message %||% getOption("gradethis.pass", "Correct!")
-      maybe_extras(pass(message, env = env, ...), praise = praise)
+      pass(message, env = env, ..., praise = praise)
     }
   } else {
     condition(cond, message, correct = TRUE)
@@ -553,12 +553,7 @@ fail_if <- function(
     assert_gradethis_condition_type_is_value(cond, "fail_if")
     if (cond) {
       message <- message %||% getOption("gradethis.fail", "Incorrect.")
-      maybe_extras(
-        fail(message, env = env, ...),
-        env = env,
-        hint = hint,
-        encourage = encourage
-      )
+      fail(message, env = env, ..., hint = hint, encourage = encourage)
     }
   } else {
     if (!missing(hint) || isTRUE(hint)) {

--- a/tests/testthat/test-graded.R
+++ b/tests/testthat/test-graded.R
@@ -611,7 +611,7 @@ test_that("extra phrases aren't duplicated", {
     random_encouragement = function() "RANDOM ENCOURAGEMENT.",
     random_praise = function() "RANDOM PRAISE."
   )
-  
+
   with_gradethis_setup(
     fail.encourage = TRUE,
     pass.praise = TRUE,
@@ -629,17 +629,17 @@ test_that("extra phrases aren't duplicated", {
           praise = TRUE
         )
       })
-      
+
       grade_fail <- grader(mock_this_exercise(.user_code = 43, .solution_code = 42))
       grade_pass <- grader(mock_this_exercise(.user_code = 42, .solution_code = 42))
     }
   )
-  
+
   expect_match_count <- function(text, pattern, n) {
     count <- length(strsplit(text, pattern)[[1]]) - 1
     expect_equal(!!count, !!n)
   }
-  
+
   expect_match_count(grade_fail$message, "RANDOM ENCOURAGEMENT", 1L)
   expect_match_count(grade_pass$message, "RANDOM PRAISE", 1L)
 })


### PR DESCRIPTION
The problem was that we were calling

```r
maybe_extras(pass(...))
```

when we should have just been calling `pass()` (or `fail()`). The extra wrapper around `maybe_extras()` added a second pass of praise or encouragement.

Fixes #280 