### PR TITLE
Fix error when `.user_code` is empty

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,18 +48,18 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v1
-      
+      - uses: r-lib/actions/setup-pandoc@v2
+
       - name: Install devel system dependencies
         if: matrix.config.os == 'ubuntu-18.04' && matrix.config.r == 'devel'
         run: sudo apt-get install -y libcurl4-openssl-dev
-      
-      - uses: r-lib/actions/setup-r-dependencies@v1
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache-version: 1
           extra-packages: rcmdcheck
-        
-      - uses: r-lib/actions/check-r-package@v1
+
+      - uses: r-lib/actions/check-r-package@v2
 
       - name: Show testthat output
         if: always()

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -19,14 +19,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         id: install-r
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           needs: |
             connect

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 * When combined with learnr version 0.10.1.9017 or later, gradethis' exercise checking function will not require that grading code absolutely return feedback unless exercise checking is at the `"check"` stage. (#276)
 * You may now call `return()` in `grade_this()` grading code to exit grading early. This is allowed in code and error checking code, but will result in an "internal error" when used in the `-check` chunk grading code (#284).
 * gradethis now includes low-level support for multiple solutions. Authors can add multiple solutions in the `-solution` chunk, separated by [code section headers](https://support.rstudio.com/hc/en-us/articles/200484568-Code-Folding-and-Sections-in-the-RStudio-IDE), e.g. `# ----`. (note only trailing dashes, `----`, are supported). These additional solutions are made available in the `.solution_code_all` object in `grade_this()` grading code and are named with the code section name if one is provided, e.g. `# first ----`. When multiple solutions are provided using the code section comments, `.solution` and `.solution_code` will default to the **last** solution. (#286)
+* `grade_this_code()` and `fail_if_code_feedback()` now return informative feedback with a neutral grade when no code is submitted and when not previously caught by learnr (#288).
 
 ### Breaking changes
 

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -170,11 +170,7 @@ detect_grade_this <- function(env = parent.frame()) {
 }
 
 is_empty_code <- function(code) {
-  if (length(code) == 0) {
-    return(FALSE)
-  }
-
-  all(!nzchar(str_trim(code)))
+  length(code) == 0 || all(!nzchar(str_trim(code)))
 }
 
 grade_code_is_empty <- function() {

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -169,18 +169,6 @@ detect_grade_this <- function(env = parent.frame()) {
   get0(".__gradethis_check_env", envir = env, ifnotfound = FALSE)
 }
 
-is_empty_code <- function(code) {
-  length(code) == 0 || all(!nzchar(str_trim(code)))
-}
-
-grade_code_is_empty <- function() {
-  graded(
-    logical(),
-    "I didn't receive your code. Did you write any?",
-    type = "info"
-  )
-}
-
 # Sentinel Values ----
 placeholder <- function(class, ...) {
   structure(list(), class = c(class, ..., "gradethis_placeholder"))

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -142,7 +142,11 @@ grade_this <- function(
       check_env <- list2env(check_env, envir = new.env(parent = emptyenv()))
     }
 
-    check_env[[".user_code"]] <- assert_user_code(.user_code, check_env)
+    empty_code <- empty_code(check_env[[".user_code"]])
+    if (!is.null(empty_code)) {
+      return(empty_code)
+    }
+
     check_env[[".__gradethis_check_env"]] <- TRUE
 
     # Ensure that check_env has expr_env as a parent
@@ -270,15 +274,15 @@ NULL
 #' @export
 .user_code <- placeholder(".user_code")
 
-assert_user_code <- function(user_code, env, frame = parent.frame()) {
-  if (is_placeholder(user_code, ".user_code")) {
-    user_code <- get_from_env(".user_code", env)
-    assert_object_found_in_env(user_code, env, "fail_if_code_feedback")
+empty_code <- function(code, check_null = FALSE) {
+  if (check_null) {
+    empty_code <- is.null(code) || length(code) == 0 || !nzchar(code)
+  } else {
+    empty_code <- length(code) && !nzchar(code)
   }
 
-  if (is.null(user_code) || length(user_code) == 0 || !nzchar(user_code)) {
-    rlang::return_from(
-      frame,
+  if (empty_code) {
+    return(
       graded(
         logical(),
         "I didn't receive your code. Did you write any?",
@@ -286,8 +290,6 @@ assert_user_code <- function(user_code, env, frame = parent.frame()) {
       )
     )
   }
-
-  user_code
 }
 
 #' @rdname grade_this-objects

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -142,6 +142,7 @@ grade_this <- function(
       check_env <- list2env(check_env, envir = new.env(parent = emptyenv()))
     }
 
+    check_env[[".user_code"]] <- assert_user_code(.user_code, check_env)
     check_env[[".__gradethis_check_env"]] <- TRUE
 
     # Ensure that check_env has expr_env as a parent
@@ -269,6 +270,26 @@ NULL
 #' @export
 .user_code <- placeholder(".user_code")
 
+assert_user_code <- function(user_code, env, frame = parent.frame()) {
+  if (is_placeholder(user_code, ".user_code")) {
+    user_code <- get_from_env(".user_code", env)
+    assert_object_found_in_env(user_code, env, "fail_if_code_feedback")
+  }
+
+  if (is.null(user_code) || length(user_code) == 0 || !nzchar(user_code)) {
+    rlang::return_from(
+      frame,
+      graded(
+        logical(),
+        "I didn't receive your code. Did you write any?",
+        type = "info"
+      )
+    )
+  }
+
+  user_code
+}
+
 #' @rdname grade_this-objects
 #' @export
 .solution_code <- placeholder(".solution_code")
@@ -300,7 +321,6 @@ NULL
 #' @rdname grade_this-objects
 #' @export
 .engine <- placeholder(".engine")
-
 
 #' Debug an exercise submission
 #'

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -169,12 +169,12 @@ detect_grade_this <- function(env = parent.frame()) {
   get0(".__gradethis_check_env", envir = env, ifnotfound = FALSE)
 }
 
-is_empty_code <- function(code, check_null = FALSE) {
-  if (check_null) {
-    is.null(code) || length(code) == 0 || !nzchar(code)
-  } else {
-    length(code) && !nzchar(code)
+is_empty_code <- function(code) {
+  if (length(code) == 0) {
+    return(FALSE)
   }
+
+  all(!nzchar(str_trim(code)))
 }
 
 grade_code_is_empty <- function() {

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -142,11 +142,6 @@ grade_this <- function(
       check_env <- list2env(check_env, envir = new.env(parent = emptyenv()))
     }
 
-    empty_code <- empty_code(check_env[[".user_code"]])
-    if (!is.null(empty_code)) {
-      return(empty_code)
-    }
-
     check_env[[".__gradethis_check_env"]] <- TRUE
 
     # Ensure that check_env has expr_env as a parent

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -169,6 +169,21 @@ detect_grade_this <- function(env = parent.frame()) {
   get0(".__gradethis_check_env", envir = env, ifnotfound = FALSE)
 }
 
+is_empty_code <- function(code, check_null = FALSE) {
+  if (check_null) {
+    is.null(code) || length(code) == 0 || !nzchar(code)
+  } else {
+    length(code) && !nzchar(code)
+  }
+}
+
+grade_code_is_empty <- function() {
+  graded(
+    logical(),
+    "I didn't receive your code. Did you write any?",
+    type = "info"
+  )
+}
 
 # Sentinel Values ----
 placeholder <- function(class, ...) {
@@ -268,24 +283,6 @@ NULL
 #' @rdname grade_this-objects
 #' @export
 .user_code <- placeholder(".user_code")
-
-empty_code <- function(code, check_null = FALSE) {
-  if (check_null) {
-    empty_code <- is.null(code) || length(code) == 0 || !nzchar(code)
-  } else {
-    empty_code <- length(code) && !nzchar(code)
-  }
-
-  if (empty_code) {
-    return(
-      graded(
-        logical(),
-        "I didn't receive your code. Did you write any?",
-        type = "info"
-      )
-    )
-  }
-}
 
 #' @rdname grade_this-objects
 #' @export

--- a/R/grade_this_code.R
+++ b/R/grade_this_code.R
@@ -220,3 +220,15 @@ grade_this_code <- function(
     grade
   }
 }
+
+is_empty_code <- function(code) {
+  length(code) == 0 || all(!nzchar(str_trim(code)))
+}
+
+grade_code_is_empty <- function() {
+  graded(
+    logical(),
+    "I didn't receive your code. Did you write any?",
+    type = "info"
+  )
+}

--- a/R/grade_this_code.R
+++ b/R/grade_this_code.R
@@ -174,9 +174,8 @@ grade_this_code <- function(
 
   # MUST wrap calling function to be able to shim in `.correct`/`.incorrect`
   function(check_env) {
-    empty_code <- empty_code(check_env[[".user_code"]])
-    if (!is.null(empty_code)) {
-      return(empty_code)
+    if (is_empty_code(check_env[[".user_code"]])) {
+      return(grade_code_is_empty())
     }
 
     check_env[[".__correct"]] <- correct

--- a/R/grade_this_code.R
+++ b/R/grade_this_code.R
@@ -174,7 +174,10 @@ grade_this_code <- function(
 
   # MUST wrap calling function to be able to shim in `.correct`/`.incorrect`
   function(check_env) {
-    check_env[[".user_code"]] <- assert_user_code(.user_code, check_env)
+    empty_code <- empty_code(check_env[[".user_code"]])
+    if (!is.null(empty_code)) {
+      return(empty_code)
+    }
 
     check_env[[".__correct"]] <- correct
     check_env[[".__incorrect"]] <- incorrect

--- a/R/grade_this_code.R
+++ b/R/grade_this_code.R
@@ -174,6 +174,8 @@ grade_this_code <- function(
 
   # MUST wrap calling function to be able to shim in `.correct`/`.incorrect`
   function(check_env) {
+    check_env[[".user_code"]] <- assert_user_code(.user_code, check_env)
+
     check_env[[".__correct"]] <- correct
     check_env[[".__incorrect"]] <- incorrect
     check_env[[".__action"]] <- action

--- a/R/graded.R
+++ b/R/graded.R
@@ -646,7 +646,7 @@ fail_if_code_feedback <- function(
     assert_object_found_in_env(user_code, env, "fail_if_code_feedback")
   }
 
-  if (is_empty_code(user_code, check_null = TRUE)) {
+  if (length(user_code) == 0 || is_empty_code(user_code)) {
     return(grade_code_is_empty())
   }
 

--- a/R/graded.R
+++ b/R/graded.R
@@ -646,7 +646,7 @@ fail_if_code_feedback <- function(
     assert_object_found_in_env(user_code, env, "fail_if_code_feedback")
   }
 
-  if (length(user_code) == 0 || is_empty_code(user_code)) {
+  if (is_empty_code(user_code)) {
     return(grade_code_is_empty())
   }
 

--- a/R/graded.R
+++ b/R/graded.R
@@ -798,12 +798,12 @@ get_from_env <- function(x, env) {
 assert_object_found_in_env <- function(obj, env, caller, throw_grade = TRUE) {
   obj_expr <- rlang::enexpr(obj)
 
-  if (!is_placeholder(obj) && !is_missing(obj)) {
+  if (!is_missing(obj) && !is_placeholder(obj)) {
     return(invisible(NULL))
   }
 
   obj_name <-
-    if (is_placeholder(obj)) {
+    if (!is_missing(obj) && is_placeholder(obj)) {
       class(obj)[1]
     } else {
       rlang::expr_text(obj_expr)

--- a/R/graded.R
+++ b/R/graded.R
@@ -641,13 +641,8 @@ fail_if_code_feedback <- function(
   encourage = getOption("gradethis.fail.encourage", FALSE),
   allow_partial_matching = getOption("gradethis.allow_partial_matching", TRUE)
 ) {
-  if (is_placeholder(user_code, ".user_code")) {
-    user_code <- get_from_env(".user_code", env)
-    assert_object_found_in_env(user_code, env, "fail_if_code_feedback")
-    if (is.null(user_code) || length(user_code) == 0 || !nzchar(user_code)) {
-      graded(logical(), "I didn't receive your code. Did you write any?", type = "info")
-    }
-  }
+  user_code <- assert_user_code(user_code, env)
+
   if (is_placeholder(solution_code, ".solution_code")) {
     solution_code <- get_from_env(".solution_code", env)
     assert_object_found_in_env(solution_code, env, "fail_if_code_feedback", throw_grade = FALSE)

--- a/R/graded.R
+++ b/R/graded.R
@@ -646,9 +646,8 @@ fail_if_code_feedback <- function(
     assert_object_found_in_env(user_code, env, "fail_if_code_feedback")
   }
 
-  empty_code <- empty_code(user_code, check_null = TRUE)
-  if (!is.null(empty_code)) {
-    return(empty_code)
+  if (is_empty_code(user_code, check_null = TRUE)) {
+    return(grade_code_is_empty())
   }
 
   if (is_placeholder(solution_code, ".solution_code")) {

--- a/R/graded.R
+++ b/R/graded.R
@@ -641,7 +641,15 @@ fail_if_code_feedback <- function(
   encourage = getOption("gradethis.fail.encourage", FALSE),
   allow_partial_matching = getOption("gradethis.allow_partial_matching", TRUE)
 ) {
-  user_code <- assert_user_code(user_code, env)
+  if (is_placeholder(user_code, ".user_code")) {
+    user_code <- get_from_env(".user_code", env)
+    assert_object_found_in_env(user_code, env, "fail_if_code_feedback")
+  }
+
+  empty_code <- empty_code(user_code, check_null = TRUE)
+  if (!is.null(empty_code)) {
+    return(empty_code)
+  }
 
   if (is_placeholder(solution_code, ".solution_code")) {
     solution_code <- get_from_env(".solution_code", env)
@@ -798,12 +806,12 @@ get_from_env <- function(x, env) {
 assert_object_found_in_env <- function(obj, env, caller, throw_grade = TRUE) {
   obj_expr <- rlang::enexpr(obj)
 
-  if (!is_missing(obj) && !is_placeholder(obj)) {
+  if (!is_placeholder(obj) && !is_missing(obj)) {
     return(invisible(NULL))
   }
 
   obj_name <-
-    if (!is_missing(obj) && is_placeholder(obj)) {
+    if (is_placeholder(obj)) {
       class(obj)[1]
     } else {
       rlang::expr_text(obj_expr)

--- a/tests/testthat/test-grade_this_code.R
+++ b/tests/testthat/test-grade_this_code.R
@@ -166,7 +166,15 @@ test_that("Spots differences in long calls", {
   user <- "gather(key = key, value = value, new_sp_m014:newrel_f65, na.rm = TRUE)" # nolint
   solution <- "gather(key = key, value = value, new_sp_m014:newrel_f65, na.rm = TRUE)" # nolint
   expect_this_code(user, solution, is_correct = TRUE)
+})
 
+test_that("grade_this_code() gives neutral feedback if code is missing", {
+  expect_graded(
+    grade_this_code()(
+      mock_this_exercise(.user_code = "", .solution_code = "rnorm(1)")
+    ),
+    is_correct = logical()
+  )
 })
 
 test_that("grade_this_code() doesn't have to return a grade", {

--- a/tests/testthat/test-graded.R
+++ b/tests/testthat/test-graded.R
@@ -259,11 +259,9 @@ test_that("fail_if_code_feedback() returns grade if code feedback", {
 
   # Expect teacher grading problem if called outside of grade_this()
   testthat::expect_message(
-    expect_graded(
-      fail_if_code_feedback(),
-      is_correct = logical(),
-      msg = "problem occurred"
-    )
+    expect_null(fail_if_code_feedback()),
+    "expected `.user_code` to be found",
+    fixed = TRUE
   )
 
 

--- a/tests/testthat/test-graded.R
+++ b/tests/testthat/test-graded.R
@@ -259,9 +259,11 @@ test_that("fail_if_code_feedback() returns grade if code feedback", {
 
   # Expect teacher grading problem if called outside of grade_this()
   testthat::expect_message(
-    expect_null(fail_if_code_feedback()),
-    "expected `.user_code` to be found",
-    fixed = TRUE
+    expect_graded(
+      fail_if_code_feedback(),
+      is_correct = logical(),
+      msg = "problem occurred"
+    )
   )
 
 

--- a/tests/testthat/test-graded.R
+++ b/tests/testthat/test-graded.R
@@ -274,6 +274,15 @@ test_that("fail_if_code_feedback() returns grade if code feedback", {
   )
 })
 
+test_that("fail_if_code_feedback() gives neutral feedback if code is missing", {
+  expect_graded(
+    grade_this(fail_if_code_feedback())(
+      mock_this_exercise(.user_code = "", .solution_code = "rnorm(1)")
+    ),
+    is_correct = logical()
+  )
+})
+
 test_that("graded() returns correct, incorrect, neutral", {
   # correct
   expect_graded(

--- a/tests/testthat/test-gradethis_exercise_checker.R
+++ b/tests/testthat/test-gradethis_exercise_checker.R
@@ -296,3 +296,12 @@ test_that("pass_if() and fail_if() work in grade_this()", {
   )
   expect_match(err$error$message, "does not accept functions or formulas")
 })
+
+test_that("grade_this() gives neutral feedback if code is missing", {
+  expect_graded(
+    grade_this()(
+      mock_this_exercise(.user_code = "", .solution_code = "rnorm(1)")
+    ),
+    is_correct = logical()
+  )
+})

--- a/tests/testthat/test-gradethis_exercise_checker.R
+++ b/tests/testthat/test-gradethis_exercise_checker.R
@@ -296,12 +296,3 @@ test_that("pass_if() and fail_if() work in grade_this()", {
   )
   expect_match(err$error$message, "does not accept functions or formulas")
 })
-
-test_that("grade_this() gives neutral feedback if code is missing", {
-  expect_graded(
-    grade_this()(
-      mock_this_exercise(.user_code = "", .solution_code = "rnorm(1)")
-    ),
-    is_correct = logical()
-  )
-})


### PR DESCRIPTION
`grade_this()` and `grade_this_code()` now give neutral feedback with no error if `.user_code` is empty.

Closes #262.

``` r
library(gradethis)

grade_this_code()(
  mock_this_exercise(.user_code = "", .solution_code = "rnorm(1)")
)
#> <gradethis_graded: [Neutral]
#>   I didn't receive your code. Did you write any?
#> >

grade_this({fail(hint = TRUE)})(
  mock_this_exercise(.user_code = "", .solution_code = "rnorm(1)")
)
#> <gradethis_graded: [Neutral]
#>   I didn't receive your code. Did you write any?
#> >
```

<sup>Created on 2022-02-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>