### PR TITLE
Allow non-R solution code

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@
 ^LICENSE\.md$
 ^CODE_OF_CONDUCT\.md$
 ^_dev$
+^\.covrignore$

--- a/.covrignore
+++ b/.covrignore
@@ -1,0 +1,1 @@
+R/staticimports.R

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 * You may now call `return()` in `grade_this()` grading code to exit grading early. This is allowed in code and error checking code, but will result in an "internal error" when used in the `-check` chunk grading code (#284).
 * gradethis now includes low-level support for multiple solutions. Authors can add multiple solutions in the `-solution` chunk, separated by [code section headers](https://support.rstudio.com/hc/en-us/articles/200484568-Code-Folding-and-Sections-in-the-RStudio-IDE), e.g. `# ----`. (note only trailing dashes, `----`, are supported). These additional solutions are made available in the `.solution_code_all` object in `grade_this()` grading code and are named with the code section name if one is provided, e.g. `# first ----`. When multiple solutions are provided using the code section comments, `.solution` and `.solution_code` will default to the **last** solution. (#286)
 * `grade_this_code()` and `fail_if_code_feedback()` now return informative feedback with a neutral grade when no code is submitted and when not previously caught by learnr (#288).
+* gradethis can now be used to grade non-R code. If learnr can evaluate the non-R code and return the result of the submitted code as an R object, then gradethis can be used to grade the submission result. Grading code is still written in R and code feedback tool designed for R will not work as expected (#290).
 
 ### Breaking changes
 

--- a/R/gradethis-package.R
+++ b/R/gradethis-package.R
@@ -20,4 +20,6 @@
 NULL
 
 # @staticimports pkg:learnr
+#   is_AsIs
+#   is_html_tag is_html_chr is_html_any
 #   knitr_engine_caption

--- a/R/gradethis-package.R
+++ b/R/gradethis-package.R
@@ -18,3 +18,6 @@
 #' @importFrom withr with_options
 ## usethis namespace: end
 NULL
+
+# @staticimports pkg:learnr
+#   knitr_engine_caption

--- a/R/mock.R
+++ b/R/mock.R
@@ -89,8 +89,7 @@ mock_this_exercise <- function(
   setup_global = NULL,
   setup_exercise = NULL
 ) {
-  .engine <- tolower(.engine)
-  is_r_code <- identical(.engine, "r")
+  is_r_code <- identical(tolower(.engine), "r")
 
   env_global <- rlang::env(globalenv())
 

--- a/R/mock.R
+++ b/R/mock.R
@@ -13,8 +13,12 @@
 #' @param .stage The stage of the exercise evaluation, defaults to `"check"`.
 #'   \pkg{learnr} stages are `"code_check"`, `"check"` or `"error_check"`. When
 #'   gradethis is used outside of learnr, this variable is typically `NULL`.
-#' @param .engine The engine of the mock exercise, must be `"r"` but is included
-#'   here for future compatibility.
+#' @param .engine The engine of the mock exercise. If the engine is not `"r"`,
+#'   then `.result` must be provided explicitly since `mock_this_exercise()`
+#'   cannot evaluate the `.user_code`.
+#' @param .result The result of the evaluation of the `.user_code`. If the
+#'   `.engine` is `"r"`, the result will be prepared automatically by evaluating
+#'   the user code.
 #' @param setup_global An optional single string or expression in braces
 #'   representing the global `setup` chunk code.
 #' @param setup_exercise An optional single string or expression in braces

--- a/R/staticimports.R
+++ b/R/staticimports.R
@@ -19,6 +19,42 @@ is_html_tag <- function(x) {
   inherits(x, c("shiny.tag", "shiny.tag.list"))
 }
 
+knitr_engine_caption <- function(engine = NULL) {
+  if (is.null(engine)) {
+    engine <- "r"
+  }
+
+  switch(
+    tolower(engine),
+    "bash" = "Bash",
+    "c" = "C",
+    "coffee" = "CoffeeScript",
+    "cc" = "C++",
+    "css" = "CSS",
+    "go" = "Go",
+    "groovy" = "Groovy",
+    "haskell" = "Haskell",
+    "js" = "JavaScript",
+    "mysql" = "MySQL",
+    "node" = "Node.js",
+    "octave" = "Octave",
+    "psql" = "PostgreSQL",
+    "python" = "Python",
+    "r" = "R",
+    "rcpp" = "Rcpp",
+    "cpp11" = "cpp11",
+    "rscript" = "Rscript",
+    "ruby" = "Ruby",
+    "perl" = "Perl",
+    "sass" = "Sass",
+    "scala" = "Scala",
+    "scss" = "SCSS",
+    "sql" = "SQL",
+    # else, return as the user provided
+    engine
+  )
+}
+
 split_code_headers <- function(code, prefix = "section") {
   if (is.null(code)) {
     return(NULL)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,7 +1,3 @@
-# @staticimports pkg:learnr
-#   is_AsIs
-#   is_html_tag is_html_chr is_html_any
-
 deparse_to_string <- function(x, width.cutoff = 500L, ...) {
   paste0(deparse(x, width.cutoff = width.cutoff, ...), collapse = "\n")
 }

--- a/man/mock_this_exercise.Rd
+++ b/man/mock_this_exercise.Rd
@@ -11,6 +11,8 @@ mock_this_exercise(
   .label = "mock",
   .engine = "r",
   .stage = "check",
+  .result = rlang::missing_arg(),
+  .error = rlang::missing_arg(),
   setup_global = NULL,
   setup_exercise = NULL
 )

--- a/man/mock_this_exercise.Rd
+++ b/man/mock_this_exercise.Rd
@@ -12,7 +12,6 @@ mock_this_exercise(
   .engine = "r",
   .stage = "check",
   .result = rlang::missing_arg(),
-  .error = rlang::missing_arg(),
   setup_global = NULL,
   setup_exercise = NULL
 )

--- a/man/mock_this_exercise.Rd
+++ b/man/mock_this_exercise.Rd
@@ -28,12 +28,17 @@ representing the solution code to this exercise.}
 
 \item{.label}{The label of the mock exercise, defaults to \code{"mock"}.}
 
-\item{.engine}{The engine of the mock exercise, must be \code{"r"} but is included
-here for future compatibility.}
+\item{.engine}{The engine of the mock exercise. If the engine is not \code{"r"},
+then \code{.result} must be provided explicitly since \code{mock_this_exercise()}
+cannot evaluate the \code{.user_code}.}
 
 \item{.stage}{The stage of the exercise evaluation, defaults to \code{"check"}.
 \pkg{learnr} stages are \code{"code_check"}, \code{"check"} or \code{"error_check"}. When
 gradethis is used outside of learnr, this variable is typically \code{NULL}.}
+
+\item{.result}{The result of the evaluation of the \code{.user_code}. If the
+\code{.engine} is \code{"r"}, the result will be prepared automatically by evaluating
+the user code.}
 
 \item{setup_global}{An optional single string or expression in braces
 representing the global \code{setup} chunk code.}

--- a/tests/testthat/helper-expect.R
+++ b/tests/testthat/helper-expect.R
@@ -226,7 +226,8 @@ expect_exercise_checker <- function(
     evaluate_result = "ignore",
     envir_prep = envir_prep,
     last_value = last_value,
-    stage = stage
+    stage = stage,
+    ...
   )
 
   if (!expect_feedback) {

--- a/tests/testthat/test-gradethis_exercise_checker.R
+++ b/tests/testthat/test-gradethis_exercise_checker.R
@@ -97,7 +97,7 @@ test_that("length 0 solution code", {
   expect_exercise_checker(
     is_correct = logical(),
     msg = "No solution is provided for this exercise.",
-    msg_type = "info",
+    msg_type = "warning",
     user_code = "1",
     check_code = "grade_this({pass(.solution)})",
     solution_code = "",

--- a/tests/testthat/test-mock.R
+++ b/tests/testthat/test-mock.R
@@ -131,3 +131,27 @@ test_that("mock_this_exercise() mocks multiple solutions", {
   expect_equal(ex$.solution_code, ex$.solution_code_all[[3]])
   expect_equal(length(ex$.solution), 3L)
 })
+
+test_that("mock_this_exercise() with non-R exercise engine", {
+  ex <- mock_this_exercise("SELECT * FROM mtcars", .engine = "sql", .result = mtcars)
+
+  expect_equal(ex$.engine, "sql")
+  expect_equal(
+    ex$.user_code,
+    "SELECT * FROM mtcars"
+  )
+  expect_equal(
+    ex$.result,
+    mtcars
+  )
+
+  # .result is required if not R engine
+  expect_error(
+    mock_this_exercise("SELECT * FROM table", .engine = "sql")
+  )
+
+  # Bare code allowed only when R engine
+  expect_error(
+    mock_this_exercise(SELECT, .engine = "sql", .result = 7)
+  )
+})


### PR DESCRIPTION
* Don't try to parse non-R solution code
* `.solution` isn't available in these cases
* Update `mock_this_exercise()` to follow same flow