### PR TITLE
Add `tolerance` argument to `*_if_equal()` functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 * gradethis now includes low-level support for multiple solutions. Authors can add multiple solutions in the `-solution` chunk, separated by [code section headers](https://support.rstudio.com/hc/en-us/articles/200484568-Code-Folding-and-Sections-in-the-RStudio-IDE), e.g. `# ----`. (note only trailing dashes, `----`, are supported). These additional solutions are made available in the `.solution_code_all` object in `grade_this()` grading code and are named with the code section name if one is provided, e.g. `# first ----`. When multiple solutions are provided using the code section comments, `.solution` and `.solution_code` will default to the **last** solution. (#286)
 * `grade_this_code()` and `fail_if_code_feedback()` now return informative feedback with a neutral grade when no code is submitted and when not previously caught by learnr (#288).
 * gradethis can now be used to grade non-R code. If learnr can evaluate the non-R code and return the result of the submitted code as an R object, then gradethis can be used to grade the submission result. Grading code is still written in R and code feedback tool designed for R will not work as expected (#290).
+* `pass_if_equal()` and `fail_if_equal()` gain a tolerance argument which is passed to `waldo::compare()`. This defaults to the same default value as `all.equal()` to avoid floating point errors when comparing numeric values (#295).
 
 ### Breaking changes
 

--- a/R/graded.R
+++ b/R/graded.R
@@ -335,6 +335,7 @@ fail <- function(
 #'   `waldo::compare(x, y)`. In `pass_if_equal()`, if no value is provided, the
 #'   exercise `.solution`, or the result of evaluating the code in the
 #'   exercise's `*-solution` chunk, will be used for the comparison.
+#' @inheritParams waldo::compare
 #' @param ... Additional arguments passed to [graded()]
 #'
 #' @return Returns a passing or failing grade if `x` and `y` are equal.
@@ -349,6 +350,7 @@ pass_if_equal <- function(
   x = .result,
   ...,
   env = parent.frame(),
+  tolerance = sqrt(.Machine$double.eps),
   praise = getOption("gradethis.pass.praise", FALSE)
 ) {
   if (is_placeholder(x, ".result")) {
@@ -360,7 +362,10 @@ pass_if_equal <- function(
     assert_object_found_in_env(y, env, "pass_if_equal")
   }
   maybe_extras(
-    grade_if_equal(x = x, y = y, message = message, correct = TRUE, env = env, ...),
+    grade_if_equal(
+      x = x, y = y,
+      message = message, correct = TRUE, env = env, tolerance = tolerance, ...
+    ),
     praise = praise
   )
 }
@@ -374,6 +379,7 @@ fail_if_equal <- function(
   x = .result,
   ...,
   env = parent.frame(),
+  tolerance = sqrt(.Machine$double.eps),
   hint = getOption("gradethis.fail.hint", FALSE),
   encourage = getOption("gradethis.fail.encourage", FALSE)
 ) {
@@ -382,18 +388,23 @@ fail_if_equal <- function(
     assert_object_found_in_env(x, env, "fail_if_equal")
   }
   maybe_extras(
-    grade_if_equal(x = x, y = y, message = message, correct = FALSE, env = env, ...),
+    grade_if_equal(
+      x = x, y = y,
+      message = message, correct = FALSE, env = env, tolerance = tolerance, ...
+    ),
     env = env,
     hint = hint,
     encourage = encourage
   )
 }
 
-grade_if_equal <- function(x, y, message, correct, env, ...) {
+grade_if_equal <- function(
+  x, y, message, correct, env, tolerance = sqrt(.Machine$double.eps), ...
+) {
   local_options_waldo_compare()
 
   compare_msg <- tryCatch(
-    waldo::compare(x, y),
+    waldo::compare(x, y, tolerance = tolerance),
     error = function(e) {
       # https://github.com/brodieG/diffobj/issues/152#issuecomment-788083359
       # waldo::compare() calls diffobj::ses() — these functions try hard to create

--- a/R/graded.R
+++ b/R/graded.R
@@ -363,8 +363,13 @@ pass_if_equal <- function(
   }
   maybe_extras(
     grade_if_equal(
-      x = x, y = y,
-      message = message, correct = TRUE, env = env, tolerance = tolerance, ...
+      x = x,
+      y = y,
+      message = message,
+      correct = TRUE,
+      env = env,
+      tolerance = tolerance,
+      ...
     ),
     praise = praise
   )
@@ -389,8 +394,13 @@ fail_if_equal <- function(
   }
   maybe_extras(
     grade_if_equal(
-      x = x, y = y,
-      message = message, correct = FALSE, env = env, tolerance = tolerance, ...
+      x = x,
+      y = y,
+      message = message,
+      correct = FALSE,
+      env = env,
+      tolerance = tolerance,
+      ...
     ),
     env = env,
     hint = hint,

--- a/man/pass_if_equal.Rd
+++ b/man/pass_if_equal.Rd
@@ -11,6 +11,7 @@ pass_if_equal(
   x = .result,
   ...,
   env = parent.frame(),
+  tolerance = sqrt(.Machine$double.eps),
   praise = getOption("gradethis.pass.praise", FALSE)
 )
 
@@ -20,6 +21,7 @@ fail_if_equal(
   x = .result,
   ...,
   env = parent.frame(),
+  tolerance = sqrt(.Machine$double.eps),
   hint = getOption("gradethis.fail.hint", FALSE),
   encourage = getOption("gradethis.fail.encourage", FALSE)
 )
@@ -44,6 +46,18 @@ the student's submission against a specific value, \code{y}.}
 
 \item{env}{environment to evaluate the glue \code{message}. Most users of
 \pkg{gradethis} will not need to use this argument.}
+
+\item{tolerance}{If non-\code{NULL}, used as threshold for ignoring small
+floating point difference when comparing numeric vectors. Setting to
+any non-\code{NULL} value will cause integer and double vectors to be compared
+based on their values, rather than their types.
+
+It uses the same algorithm as \code{\link[=all.equal]{all.equal()}}, i.e., first we generate
+\code{x_diff} and \code{y_diff} by subsetting \code{x} and \code{y} to look only locations
+with differences. Then we check that
+\code{mean(abs(x_diff - y_diff)) / mean(abs(y_diff))} (or just
+\code{mean(abs(x_diff - y_diff))} if \code{y_diff} is small) is less than
+\code{tolerance}.}
 
 \item{praise}{Include a random praising phrase with \code{\link[=random_praise]{random_praise()}}? The
 default value of \code{praise} can be set using \code{\link[=gradethis_setup]{gradethis_setup()}} or the

--- a/tests/testthat/test-graded.R
+++ b/tests/testthat/test-graded.R
@@ -139,6 +139,28 @@ test_that("fail_if_equal() in grade_this()", {
   )
 })
 
+test_that("pass_if_equal() with tolerance", {
+  # pass
+  expect_graded(
+    pass_if_equal(y = 2, x = sqrt(2) ^ 2),
+    is_correct = TRUE
+  )
+
+  # no pass
+  expect_null(pass_if_equal(y = 2, x = sqrt(2) ^ 2, tolerance = 0))
+})
+
+test_that("fail_if_equal() with tolerance", {
+  # fail
+  expect_graded(
+    fail_if_equal(y = 2, x = sqrt(2) ^ 2),
+    is_correct = FALSE
+  )
+
+  # no fail
+  expect_null(fail_if_equal(y = 2, x = sqrt(2) ^ 2, tolerance = 0))
+})
+
 test_that("fail_if_code_feedback() returns grade if code feedback", {
   # code feedback message by default
   expect_graded(


### PR DESCRIPTION
``` r
library(gradethis)

pass_if_equal(y = 2, x = sqrt(2) ^ 2)
#> <gradethis_graded: [Correct] Superb work! Correct!>

pass_if_equal(y = 2, x = sqrt(2) ^ 2, tolerance = NULL)
#> NULL
```

<sup>Created on 2022-03-10 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #294.