### PR TITLE
Attemp to construct `solution_code_all` in `grade_code()` if it's missing

### DIFF
--- a/R/grade_code.R
+++ b/R/grade_code.R
@@ -120,6 +120,12 @@ grade_code <- function(
     }
 
     solution_code_all <- check_env$.solution_code_all
+    # If `.solution_code_all` is missing, make it from `.solution_code`
+    if (is.null(solution_code_all) || length(str2expression(solution_code_all)) == 0) {
+      solution_code_all <- solutions_prepare(check_env$.solution_code)
+    }
+
+    # If `.solution_code_all` is still missing, return an error
     if (is.null(solution_code_all) || length(str2expression(solution_code_all)) == 0) {
       return(legacy_graded(
         correct = FALSE,

--- a/tests/testthat/helper-expect.R
+++ b/tests/testthat/helper-expect.R
@@ -81,10 +81,6 @@ expect_grade_code <- function(
   is_correct,
   msg = NULL
 ) {
-  if (is.null(solution_code_all) && !is.null(solution_code)) {
-    solution_code_all <- solutions_prepare(solution_code)
-  }
-
   check_env <- create_learnr_env(
     user_code, solution_code, solution_code_all, envir_prep, eval = FALSE
   )


### PR DESCRIPTION
If `solution_code_all` is missing, `grade_code()` now attempt to construct it from `solution_code`.

``` r
library(gradethis)

grade_code()(list(.user_code = "1", .solution_code = "1"))
#> <gradethis_graded: [Correct] Out of this world!  >
```

<sup>Created on 2022-03-29 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #297.