### PR TITLE
Roll back new `solution_code_all` argument

### DIFF
--- a/R/code_feedback.R
+++ b/R/code_feedback.R
@@ -167,9 +167,16 @@ code_feedback <- function(
 ) {
   ellipsis::check_dots_empty()
 
-  env <- resolve_placeholder(env, default = parent.frame())
-  user_code <- resolve_placeholder(user_code)
-  solution_code <- resolve_placeholder(solution_code)
+  resolve_placeholder_parent <-
+    purrr::partial(
+      resolve_placeholder,
+      env_find = !!parent.frame(),
+      throw_grade = FALSE
+    )
+
+  env <- resolve_placeholder_parent(env, default = parent.frame())
+  user_code <- resolve_placeholder_parent(user_code, default = NULL)
+  solution_code <- resolve_placeholder_parent(solution_code, default = NULL)
 
   if (inherits(solution_code, "gradethis_solutions") || is.list(solution_code)) {
     solution_code <- solution_code_closest(user_code, solution_code)

--- a/R/code_feedback.R
+++ b/R/code_feedback.R
@@ -128,7 +128,7 @@
 #' grader(submission_wrong)
 #' @param user_code,solution_code String containing user or solution code. By
 #'   default, when used in [grade_this()], [.user_code] is retrieved for the
-#'   [user_code]. `solution_code` may also be a list containing multiple
+#'   [.user_code]. `solution_code` may also be a list containing multiple
 #'   solution variations, so by default in [grade_this()] [.solution_code_all]
 #'   is found and used for `solution_code`. You may also use `.solution_code` if
 #'   there is only one solution.

--- a/R/code_feedback.R
+++ b/R/code_feedback.R
@@ -126,12 +126,12 @@
 #'   give_code_feedback(grade_this_code(incorrect = "{random_encouragement()}"))
 #' # ```
 #' grader(submission_wrong)
-#' @param user_code,solution_code String containing user or solution code. For
-#'   ease of use in [grade_this()], [.user_code] or [.solution_code] are by
-#'   default retrieved from the calling environment.
-#' @param solution_code_all A list containing the code of all solutions when
-#'   multiple solutions are provided. For ease of use in [grade_this()],
-#'   [.solution_code_all] is by default retrieved from the calling environment.
+#' @param user_code,solution_code String containing user or solution code. By
+#'   default, when used in [grade_this()], [.user_code] is retrieved for the
+#'   [user_code]. `solution_code` may also be a list containing multiple
+#'   solution variations, so by default in [grade_this()] [.solution_code_all]
+#'   is found and used for `solution_code`. You may also use `.solution_code` if
+#'   there is only one solution.
 #' @param env Environment used to standardize formals of the user and solution
 #'   code. Defaults to retrieving [.envir_prep] from the calling environment. If
 #'   not found, the [parent.frame()] will be used.
@@ -160,40 +160,20 @@
 #' @export
 code_feedback <- function(
   user_code = .user_code,
-  solution_code = .solution_code,
-  solution_code_all = .solution_code_all,
+  solution_code = .solution_code_all,
   env = .envir_prep,
   ...,
   allow_partial_matching = getOption("gradethis.allow_partial_matching", TRUE)
 ) {
   ellipsis::check_dots_empty()
 
-  if (is_placeholder(env, ".envir_prep")) {
-    env <- get0(".envir_prep", parent.frame(), ifnotfound = .envir_prep)
-    if (is_placeholder(env)) {
-      env <- parent.frame()
-    }
-    assert_not_placeholder(env)
-  }
-  if (is_placeholder(user_code, ".user_code")) {
-    user_code <- get0(".user_code", parent.frame())
-    assert_not_placeholder(user_code)
-  }
-  if (is_placeholder(solution_code_all, ".solution_code_all")) {
-    solution_code_all <- get0(".solution_code_all", parent.frame())
+  env <- resolve_placeholder(env, default = parent.frame())
+  user_code <- resolve_placeholder(user_code)
+  solution_code <- resolve_placeholder(solution_code)
 
-    # If .solution_code_all is not present, create it from .solution_code
-    if (is_placeholder(solution_code_all, ".solution_code_all")) {
-      if (is_placeholder(solution_code, ".solution_code")) {
-        solution_code <- get0(".solution_code", parent.frame())
-        assert_not_placeholder(solution_code)
-      }
-
-      solution_code_all <- solutions_prepare(solution_code)
-    }
+  if (inherits(solution_code, "gradethis_solutions") || is.list(solution_code)) {
+    solution_code <- solution_code_closest(user_code, solution_code)
   }
-
-  solution_code <- solution_code_closest(user_code, solution_code_all)
 
   user_expr <- to_expr(user_code, "user_code")
   solution_expr <- to_expr(solution_code, "solution_code")
@@ -307,8 +287,7 @@ which.min.last <- function(x) {
 #' @export
 maybe_code_feedback <- function(
   user_code = get0(".user_code", parent.frame()),
-  solution_code = get0(".solution_code", parent.frame()),
-  solution_code_all = get0(".solution_code_all", parent.frame()),
+  solution_code = get0(".solution_code_all", parent.frame()),
   env = get0(".envir_prep", parent.frame(), ifnotfound = parent.frame()),
   ...,
   allow_partial_matching = getOption("gradethis.allow_partial_matching", TRUE),
@@ -352,7 +331,6 @@ maybe_code_feedback <- function(
       code_feedback_val <- code_feedback(
         user_code = user_code,
         solution_code = solution_code,
-        solution_code_all = solution_code_all,
         env = env,
         allow_partial_matching = allow_partial_matching
       )

--- a/R/grade_code.R
+++ b/R/grade_code.R
@@ -135,7 +135,7 @@ grade_code <- function(
 
     message <- code_feedback(
       user_code = user_code,
-      solution_code_all = solution_code_all,
+      solution_code = solution_code_all,
       env = check_env,
       allow_partial_matching = allow_partial_matching
     )

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -174,10 +174,27 @@ is_placeholder <- function(x, which = "gradethis_placeholder") {
   inherits(x, which)
 }
 
-assert_not_placeholder <- function(x) {
+assert_not_placeholder <- function(x, caller = rlang::caller_call()) {
   if (is_placeholder(x)) {
-    rlang::abort(glue::glue("Unable to find value for placeholder `{class(x)[1]}`"))
+    msg <- glue::glue("Unable to find value for placeholder `{class(x)[1]}`")
+    rlang::abort(msg, call = caller)
   }
+  x
+}
+
+resolve_placeholder <- function(
+  x,
+  default = rlang::missing_arg(),
+  env_find = parent.frame(n = 2)
+) {
+  if (is_placeholder(x)) {
+    placeholder_name <- class(x)[[1]]
+    x <- get0(placeholder_name, env_find, ifnotfound = x)
+  }
+  if (is_placeholder(x) && !rlang::is_missing(default)) {
+    return(default)
+  }
+  assert_not_placeholder(x, caller = rlang::caller_call())
 }
 
 # @export

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -174,15 +174,7 @@ is_placeholder <- function(x, which = "gradethis_placeholder") {
   inherits(x, which)
 }
 
-assert_not_placeholder <- function(x, caller = rlang::caller_call()) {
-  if (is_placeholder(x)) {
-    msg <- glue::glue("Unable to find value for placeholder `{class(x)[1]}`")
-    rlang::abort(msg, call = caller)
-  }
-  x
-}
-
-assert_object_found_in_env <- function(obj, env, caller, obj_name = NULL, throw_grade = TRUE) {
+assert_placeholder_resolved <- function(obj, env, caller, obj_name = NULL, throw_grade = TRUE) {
   obj_name <- obj_name %||% rlang::expr_label(rlang::enexpr(obj))
 
   if (!is_placeholder(obj) && !is_missing(obj)) {
@@ -239,7 +231,7 @@ resolve_placeholder <- function(
   }
 
   caller <- as.character(rlang::caller_call()[[1]])
-  assert_object_found_in_env(
+  assert_placeholder_resolved(
     obj = x,
     env = env_find,
     caller = caller,

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -182,7 +182,7 @@ assert_placeholder_resolved <- function(
   throw_grade = TRUE,
   env_return_from = parent.frame(n = 2)
 ) {
-  obj_name <- obj_name %||% rlang::expr_label(rlang::enexpr(obj))
+  obj_expr <- rlang::enexpr(obj)
 
   if (!is_placeholder(obj) && !is_missing(obj)) {
     return(invisible(obj))
@@ -192,7 +192,7 @@ assert_placeholder_resolved <- function(
     if (is_placeholder(obj)) {
       class(obj)[1]
     } else {
-      rlang::expr_text(obj_expr)
+      obj_name %||% rlang::expr_label(obj_expr)
     }
 
   label <- env$.label

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -184,17 +184,32 @@ assert_not_placeholder <- function(x, caller = rlang::caller_call()) {
 
 resolve_placeholder <- function(
   x,
+  env_find = parent.frame(n = 2),
   default = rlang::missing_arg(),
-  env_find = parent.frame(n = 2)
+  throw_grade = TRUE
 ) {
-  if (is_placeholder(x)) {
-    placeholder_name <- class(x)[[1]]
-    x <- get0(placeholder_name, env_find, ifnotfound = x)
+  x_label <- rlang::expr_label(rlang::enexpr(x))
+
+  if (!is_placeholder(x)) {
+    return(x)
   }
+
+  placeholder_name <- class(x)[[1]]
+  x <- get0(placeholder_name, env_find, ifnotfound = x)
+
   if (is_placeholder(x) && !rlang::is_missing(default)) {
+    # it's still a placeholder and we have a default, return that instead
     return(default)
   }
-  assert_not_placeholder(x, caller = rlang::caller_call())
+
+  caller <- as.character(rlang::caller_call()[[1]])
+  assert_object_found_in_env(
+    obj = x,
+    env = env_find,
+    caller = caller,
+    obj_name = x_label,
+    throw_grade = throw_grade
+  )
 }
 
 # @export

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -182,6 +182,42 @@ assert_not_placeholder <- function(x, caller = rlang::caller_call()) {
   x
 }
 
+assert_object_found_in_env <- function(obj, env, caller, obj_name = NULL, throw_grade = TRUE) {
+  obj_name <- obj_name %||% rlang::expr_label(rlang::enexpr(obj))
+
+  if (!is_placeholder(obj) && !is_missing(obj)) {
+    return(invisible(obj))
+  }
+
+  obj_name <-
+    if (is_placeholder(obj)) {
+      class(obj)[1]
+    } else {
+      rlang::expr_text(obj_expr)
+    }
+
+  label <- env$.label
+  label <- if (!is.null(label)) paste0("In exercise `", label, "`: ")
+  msg_obj_not_found <- paste0(
+    label,
+    "`", caller, "()`: expected `", obj_name, "` to be found",
+    " in its calling environment or the environment specified by `env`.",
+    " Did you call `", caller, "()`",
+    " inside `grade_this()` or `grade_this_code()`?"
+  )
+  message(msg_obj_not_found)
+
+  if (isTRUE(throw_grade)) {
+    # Signal problem with grading code
+    signal_grade(
+      grade_grading_problem(error = list(message = msg_obj_not_found)),
+      parent.frame()
+    )
+  }
+
+  obj
+}
+
 resolve_placeholder <- function(
   x,
   env_find = parent.frame(n = 2),

--- a/R/graded.R
+++ b/R/graded.R
@@ -834,42 +834,6 @@ get_from_env <- function(x, env) {
   get0(x, envir = env, ifnotfound = missing_arg())
 }
 
-assert_object_found_in_env <- function(obj, env, caller, obj_name = NULL, throw_grade = TRUE) {
-  obj_name <- obj_name %||% rlang::expr_label(rlang::enexpr(obj))
-
-  if (!is_placeholder(obj) && !is_missing(obj)) {
-    return(invisible(obj))
-  }
-
-  obj_name <-
-    if (is_placeholder(obj)) {
-      class(obj)[1]
-    } else {
-      rlang::expr_text(obj_expr)
-    }
-
-  label <- env$.label
-  label <- if (!is.null(label)) paste0("In exercise `", label, "`: ")
-  msg_obj_not_found <- paste0(
-    label,
-    "`", caller, "()`: expected `", obj_name, "` to be found",
-    " in its calling environment or the environment specified by `env`.",
-    " Did you call `", caller, "()`",
-    " inside `grade_this()` or `grade_this_code()`?"
-  )
-  message(msg_obj_not_found)
-
-  if (isTRUE(throw_grade)) {
-    # Signal problem with grading code
-    signal_grade(
-      grade_grading_problem(error = list(message = msg_obj_not_found)),
-      parent.frame()
-    )
-  }
-
-  obj
-}
-
 maybe_extras <- function(
   expr,
   env = NULL,

--- a/R/graded.R
+++ b/R/graded.R
@@ -686,7 +686,7 @@ fail_if <- function(
 fail_if_code_feedback <- function(
   message = NULL,
   user_code = .user_code,
-  solution_code_all = .solution_code_all,
+  solution_code = .solution_code_all,
   ...,
   env = parent.frame(),
   hint = TRUE,
@@ -702,15 +702,15 @@ fail_if_code_feedback <- function(
     return(grade_code_is_empty())
   }
 
-  if (is_placeholder(solution_code_all, ".solution_code_all")) {
-    solution_code_all <- get_from_env(".solution_code_all", env)
-    assert_object_found_in_env(solution_code_all, env, "fail_if_code_feedback", throw_grade = FALSE)
+  if (is_placeholder(solution_code)) {
+    solution_code <- get_from_env(class(solution_code)[1], env)
+    assert_object_found_in_env(solution_code, env, "fail_if_code_feedback", throw_grade = FALSE)
     if (
-      is_placeholder(solution_code_all) ||
-        is_missing(solution_code_all) ||
-        is.null(solution_code_all) ||
-        length(solution_code_all) == 0 ||
-        !any(nzchar(solution_code_all))
+      is_placeholder(solution_code) ||
+        is_missing(solution_code) ||
+        is.null(solution_code) ||
+        length(solution_code) == 0 ||
+        !any(nzchar(solution_code))
     ) {
       # user_code can't be missing, but don't fail if solution code is missing
       return()
@@ -720,7 +720,7 @@ fail_if_code_feedback <- function(
 
   feedback <- code_feedback(
     user_code = user_code,
-    solution_code_all = solution_code_all,
+    solution_code = solution_code,
     env = env_feedback,
     allow_partial_matching = allow_partial_matching
   )

--- a/R/graded.R
+++ b/R/graded.R
@@ -830,10 +830,6 @@ legacy_graded <- function(...) {
   )
 }
 
-get_from_env <- function(x, env) {
-  get0(x, envir = env, ifnotfound = missing_arg())
-}
-
 maybe_extras <- function(
   expr,
   env = NULL,

--- a/man/code_feedback.Rd
+++ b/man/code_feedback.Rd
@@ -37,7 +37,7 @@ give_code_feedback(
 \arguments{
 \item{user_code, solution_code}{String containing user or solution code. By
 default, when used in \code{\link[=grade_this]{grade_this()}}, \link{.user_code} is retrieved for the
-\link{user_code}. \code{solution_code} may also be a list containing multiple
+\link{.user_code}. \code{solution_code} may also be a list containing multiple
 solution variations, so by default in \code{\link[=grade_this]{grade_this()}} \link{.solution_code_all}
 is found and used for \code{solution_code}. You may also use \code{.solution_code} if
 there is only one solution.}

--- a/man/code_feedback.Rd
+++ b/man/code_feedback.Rd
@@ -8,8 +8,7 @@
 \usage{
 code_feedback(
   user_code = .user_code,
-  solution_code = .solution_code,
-  solution_code_all = .solution_code_all,
+  solution_code = .solution_code_all,
   env = .envir_prep,
   ...,
   allow_partial_matching = getOption("gradethis.allow_partial_matching", TRUE)
@@ -17,8 +16,7 @@ code_feedback(
 
 maybe_code_feedback(
   user_code = get0(".user_code", parent.frame()),
-  solution_code = get0(".solution_code", parent.frame()),
-  solution_code_all = get0(".solution_code_all", parent.frame()),
+  solution_code = get0(".solution_code_all", parent.frame()),
   env = get0(".envir_prep", parent.frame(), ifnotfound = parent.frame()),
   ...,
   allow_partial_matching = getOption("gradethis.allow_partial_matching", TRUE),
@@ -37,13 +35,12 @@ give_code_feedback(
 )
 }
 \arguments{
-\item{user_code, solution_code}{String containing user or solution code. For
-ease of use in \code{\link[=grade_this]{grade_this()}}, \link{.user_code} or \link{.solution_code} are by
-default retrieved from the calling environment.}
-
-\item{solution_code_all}{A list containing the code of all solutions when
-multiple solutions are provided. For ease of use in \code{\link[=grade_this]{grade_this()}},
-\link{.solution_code_all} is by default retrieved from the calling environment.}
+\item{user_code, solution_code}{String containing user or solution code. By
+default, when used in \code{\link[=grade_this]{grade_this()}}, \link{.user_code} is retrieved for the
+\link{user_code}. \code{solution_code} may also be a list containing multiple
+solution variations, so by default in \code{\link[=grade_this]{grade_this()}} \link{.solution_code_all}
+is found and used for \code{solution_code}. You may also use \code{.solution_code} if
+there is only one solution.}
 
 \item{env}{Environment used to standardize formals of the user and solution
 code. Defaults to retrieving \link{.envir_prep} from the calling environment. If

--- a/man/fail_if_code_feedback.Rd
+++ b/man/fail_if_code_feedback.Rd
@@ -22,14 +22,14 @@ string that will be processed with \code{\link[glue:glue]{glue::glue()}}.}
 
 \item{user_code}{String containing user or solution code. By
 default, when used in \code{\link[=grade_this]{grade_this()}}, \link{.user_code} is retrieved for the
-\link{user_code}. \code{solution_code} may also be a list containing multiple
+\link{.user_code}. \code{solution_code} may also be a list containing multiple
 solution variations, so by default in \code{\link[=grade_this]{grade_this()}} \link{.solution_code_all}
 is found and used for \code{solution_code}. You may also use \code{.solution_code} if
 there is only one solution.}
 
 \item{solution_code}{String containing user or solution code. By
 default, when used in \code{\link[=grade_this]{grade_this()}}, \link{.user_code} is retrieved for the
-\link{user_code}. \code{solution_code} may also be a list containing multiple
+\link{.user_code}. \code{solution_code} may also be a list containing multiple
 solution variations, so by default in \code{\link[=grade_this]{grade_this()}} \link{.solution_code_all}
 is found and used for \code{solution_code}. You may also use \code{.solution_code} if
 there is only one solution.}

--- a/man/fail_if_code_feedback.Rd
+++ b/man/fail_if_code_feedback.Rd
@@ -7,7 +7,7 @@
 fail_if_code_feedback(
   message = NULL,
   user_code = .user_code,
-  solution_code_all = .solution_code_all,
+  solution_code = .solution_code_all,
   ...,
   env = parent.frame(),
   hint = TRUE,
@@ -20,13 +20,19 @@ fail_if_code_feedback(
 grading helper functions other than \code{\link[=graded]{graded()}}, \code{message} is a template
 string that will be processed with \code{\link[glue:glue]{glue::glue()}}.}
 
-\item{user_code}{String containing user or solution code. For
-ease of use in \code{\link[=grade_this]{grade_this()}}, \link{.user_code} or \link{.solution_code} are by
-default retrieved from the calling environment.}
+\item{user_code}{String containing user or solution code. By
+default, when used in \code{\link[=grade_this]{grade_this()}}, \link{.user_code} is retrieved for the
+\link{user_code}. \code{solution_code} may also be a list containing multiple
+solution variations, so by default in \code{\link[=grade_this]{grade_this()}} \link{.solution_code_all}
+is found and used for \code{solution_code}. You may also use \code{.solution_code} if
+there is only one solution.}
 
-\item{solution_code_all}{A list containing the code of all solutions when
-multiple solutions are provided. For ease of use in \code{\link[=grade_this]{grade_this()}},
-\link{.solution_code_all} is by default retrieved from the calling environment.}
+\item{solution_code}{String containing user or solution code. By
+default, when used in \code{\link[=grade_this]{grade_this()}}, \link{.user_code} is retrieved for the
+\link{user_code}. \code{solution_code} may also be a list containing multiple
+solution variations, so by default in \code{\link[=grade_this]{grade_this()}} \link{.solution_code_all}
+is found and used for \code{solution_code}. You may also use \code{.solution_code} if
+there is only one solution.}
 
 \item{...}{
   Arguments passed on to \code{\link[=graded]{graded}}

--- a/tests/testthat/helper-expect.R
+++ b/tests/testthat/helper-expect.R
@@ -126,6 +126,7 @@ expect_graded <- function(
   is_correct,
   msg = NULL
 ) {
+  grade <- eval_gradethis(grade)
   expect_s3_class(grade, "gradethis_graded")
   if (identical(is_correct, logical(0))) {
     expect_equal(grade$correct, logical(0))

--- a/tests/testthat/test-code_feedback.R
+++ b/tests/testthat/test-code_feedback.R
@@ -16,19 +16,19 @@ test_that("code_feedback() returns a string if there are differences or NULL", {
 
 test_that("code_feedback() finds the closest match if multiple solutions", {
   expect_equal(
-    code_feedback("a", solution_code_all = gradethis_solutions("aa", "bb")),
+    code_feedback("a", solution_code = gradethis_solutions("aa", "bb")),
     "I expected `aa` where you wrote `a`."
   )
 
   # If there's a tie including the last option, the last option is selected
   expect_equal(
-    code_feedback("a", solution_code_all = gradethis_solutions("b", "c")),
+    code_feedback("a", solution_code = gradethis_solutions("b", "c")),
     "I expected `c` where you wrote `a`."
   )
 
   # If there's a tie not including the last option, the first option is selected
   expect_equal(
-    code_feedback("a", solution_code_all = gradethis_solutions("b", "c", "xyz")),
+    code_feedback("a", solution_code = gradethis_solutions("b", "c", "xyz")),
     "I expected `b` where you wrote `a`."
   )
 })

--- a/tests/testthat/test-graded.R
+++ b/tests/testthat/test-graded.R
@@ -2,24 +2,26 @@ test_that("pass_if_equal() finds .result and .solution automatically", {
   env <- new.env()
 
   # missing .result
-  pass1 <- testthat::expect_message(
-    pass_if_equal(env = env), ".result", fixed = TRUE
-  )
-  expect_graded(
-    pass1,
-    is_correct = logical(0),
-    msg = "problem occurred"
-  )
+  pass1 <-
+    testthat::expect_message(
+      expect_graded(
+        pass_if_equal(env = env),
+        is_correct = logical(0),
+        msg = "problem occurred"
+      ),
+      ".result",
+      fixed = TRUE
+    )
 
   # missing .solution
   eval(quote(.result <- 12), envir = env)
   pass2 <- testthat::expect_message(
-    pass_if_equal(env = env), ".solution", fixed = TRUE
-  )
-  expect_graded(
-    pass2,
-    is_correct = logical(0),
-    msg = "problem occurred"
+    expect_graded(
+      pass_if_equal(env = env),
+      is_correct = logical(0),
+      msg = "problem occurred"
+    ),
+    ".solution", fixed = TRUE
   )
 
   # Missing .solution but comparison value provided
@@ -42,12 +44,13 @@ test_that("fail_if_equal() finds .result", {
 
   # missing .result
   fail1 <- testthat::expect_message(
-    fail_if_equal(env = env), ".result", fixed = TRUE
-  )
-  expect_graded(
-    fail1,
-    is_correct = logical(),
-    msg = "problem occurred"
+    expect_graded(
+      fail_if_equal(env = env),
+      is_correct = logical(),
+      msg = "problem occurred"
+    ),
+    regexp = ".result",
+    fixed = TRUE
   )
 
   # Has .result (not equal, doesn't fail)


### PR DESCRIPTION
Now `solution_code` for `code_feedback()` and related functions is the single entry point for solution code. Internally, it will differentiate between a single character solution and a list of multiple solutions.

```r
code_feedback(
  "runif(1)",
  "runif(10)"
)
#> In `runif(1)`, I expected `10` where you wrote `1`.

code_feedback(
  "runif(1)",
  list("rnorm(10)", "runif(10)")
)
#> In `runif(1)`, I expected `10` where you wrote `1`.

code_feedback(
  "punif(1)",
  gradethis_solutions("rnorm(10)", "runif(10)", "rbinom(10)")
)
#> I expected you to call `runif()` where you called `punif()`.
```