### PR TITLE
Exposed matched solution details in `pass_if_equal()` and document multiple solutions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
 * gradethis now includes support for multiple solutions with different results. The solutions are made available in the `.solution_all` object in `grade_this()` grading code. `pass_if_equal()` gains support for multiple solutions as its `y` argument. If `.solution_all` is used as the `y` argument of `pass_if_equal()`, it will return a passing grade if `x` matches any of the multiple solutions (#296).
 * `code_feedback()` now supports multiple solutions. By default, `code_feedback()` now looks for `.solution_code_all`. If multiple solutions are present, string distance is used to determine the closest solution to `.user_code` and give feedback based on that solution. Functions that call `code_feedback()` internally (`grade_this_code()`, `fail_if_code_feedback()` and `maybe_code_feedback()`) inherit the same functionality (#289).
 * The `solution_code` argument of `code_feedback()` is now the single entry-point for solution code in `code_feedback()`, `fail_if_code_feedback()` and other functions that work with both `.solution_code` and `.solution_code_all`. In these cases, the default argument values will use multiple solutions if they exist (#305).
+* `pass_if_equal()` supports multiple solutions when authors set `y = .solution_all` to compare the student's result with all solutions. For additional details, please see the new section, _Comparing with Multiple Solutions_, in `?pass_if_equal` (#306).
 
 ### Breaking changes
 

--- a/R/graded.R
+++ b/R/graded.R
@@ -830,6 +830,10 @@ legacy_graded <- function(...) {
   )
 }
 
+get_from_env <- function(x, env) {
+  get0(x, envir = env, ifnotfound = missing_arg())
+}
+
 maybe_extras <- function(
   expr,
   env = NULL,

--- a/man/pass_if_equal.Rd
+++ b/man/pass_if_equal.Rd
@@ -161,9 +161,13 @@ below mocks the process of a student submitting an attempt.\if{html}{\out{<div c
 
 If they submit code that returns one of the three possible solutions, they
 receive positive feedback.\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits("mtcars[mtcars$cyl == 4, ]")
-}\if{html}{\out{</div>}}\preformatted{## <gradethis_graded: [Correct] The cars in your result all have four cylinders!>
+}\if{html}{\out{</div>}}\preformatted{## <gradethis_graded: [Correct]
+##   The cars in your result all have four cylinders!
+## >
 }\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits("mtcars[mtcars$cyl == 6, ]")
-}\if{html}{\out{</div>}}\preformatted{## <gradethis_graded: [Correct] The cars in your result all have six cylinders!>
+}\if{html}{\out{</div>}}\preformatted{## <gradethis_graded: [Correct]
+##   The cars in your result all have six cylinders!
+## >
 }
 
 Notice that the solution label appears in the feedback message. When
@@ -178,8 +182,8 @@ available for use in the glue string provided to \code{message}:
 If the student submits incorrect code, \code{pass_if_equal()} defers to later
 grading code.\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits("mtcars[mtcars$cyl < 8, ]")
 }\if{html}{\out{</div>}}\preformatted{## <gradethis_graded: [Incorrect]
-##   Incorrect. In `mtcars[mtcars$cyl < 8, ]`, I expected you to call `==` where you called `<`. Try it
-##   again. Perseverence is the key to success.
+##   Incorrect. In `mtcars[mtcars$cyl < 8, ]`, I expected you to call `==`
+##   where you called `<`. Let's try it again.
 ## >
 }
 

--- a/man/pass_if_equal.Rd
+++ b/man/pass_if_equal.Rd
@@ -110,6 +110,85 @@ equal.
 equal.
 }}
 
+\section{Comparing with Multiple Solutions}{
+
+By default, \code{pass_if_equal()} will compare with \code{.solution}, or the final
+value returned by the entire \code{-solution} chunk (in other words, the last
+solution). This default behavior covers exercises with a single solution and
+exercises with multiple solutions that all return the same value.
+
+When your exercise has \strong{multiple solutions with different results},
+\code{pass_if_equal()} can compare the student's result to each of the solutions
+to return a passing grade when the result matches any of the values returned
+by the set of solutions. You can opt into this behavior by calling\if{html}{\out{<div class="sourceCode r">}}\preformatted{pass_if_equal(.solution_all)
+}\if{html}{\out{</div>}}
+
+Note that this causes \code{pass_if_equal()} to evaluate each of the solutions in
+the set, and may increase the computation time.
+
+Here's a small example. Suppose an exercise asks students to filter \code{mtcars}
+to include only cars with the same number of cylinders. Students are free to
+pick cars with 4, 6, or 8 cylinders, and so your \code{-solution} chunk would
+include this code:\if{html}{\out{<div class="sourceCode r">}}\preformatted{ex_solution <- "
+# four cylinders ----
+mtcars[mtcars$cyl == 4, ]
+
+# six cylinders ----
+mtcars[mtcars$cyl == 6, ]
+
+# eight cylinders ----
+mtcars[mtcars$cyl == 8, ]
+"
+}\if{html}{\out{</div>}}
+
+In the \code{-check} chunk, you'd call \code{\link[=grade_this]{grade_this()}} and ask \code{pass_if_equal()} to
+compare the student's result to all of the solutions.\if{html}{\out{<div class="sourceCode r">}}\preformatted{ex_check <- grade_this(\{
+  pass_if_equal(
+    y = .solution_all,
+    message = "The cars in your result all have \{.solution_label\}!"
+   )
+
+  fail()
+\})
+}\if{html}{\out{</div>}}
+
+What happens when a student submits one of these solutions? This function
+below mocks the process of a student submitting an attempt.\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits <- function(code) \{
+  submission <- mock_this_exercise(!!code, !!ex_solution)
+  ex_check(submission)
+\}
+}\if{html}{\out{</div>}}
+
+If they submit code that returns one of the three possible solutions, they
+receive positive feedback.\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits("mtcars[mtcars$cyl == 4, ]")
+}\if{html}{\out{</div>}}\preformatted{## <gradethis_graded: [Correct] The cars in your result all have four cylinders!>
+}\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits("mtcars[mtcars$cyl == 6, ]")
+}\if{html}{\out{</div>}}\preformatted{## <gradethis_graded: [Correct] The cars in your result all have six cylinders!>
+}
+
+Notice that the solution label appears in the feedback message. When
+\code{pass_if_equal()} picks a solution as correct, three variables are made
+available for use in the glue string provided to \code{message}:
+\itemize{
+\item \code{.solution_label}: The heading label of the matching solution
+\item \code{.solution_code}: The code of the matching solution
+\item \code{.solution}: The value of the evaluated matching solution code
+}
+
+If the student submits incorrect code, \code{pass_if_equal()} defers to later
+grading code.\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits("mtcars[mtcars$cyl < 8, ]")
+}\if{html}{\out{</div>}}\preformatted{## <gradethis_graded: [Incorrect]
+##   Incorrect. In `mtcars[mtcars$cyl < 8, ]`, I expected you to call `==` where you called `<`. Try it
+##   again. Perseverence is the key to success.
+## >
+}
+
+Here, because \code{\link[=fail]{fail()}} provides \code{\link[=code_feedback]{code_feedback()}} by default, and because
+\code{\link[=code_feedback]{code_feedback()}} is also aware of the multiple solutions for this exercise,
+the code feedback picks the \emph{eight cylinders} solution and gives advice
+based on that particular solution.
+}
+
 \examples{
 # Suppose our prompt is to find the cars in `mtcars` with 6 cylinders...
 

--- a/tests/testthat/test-graded.R
+++ b/tests/testthat/test-graded.R
@@ -114,36 +114,42 @@ test_that("pass_if_equal() in grade_this()", {
 
 test_that("pass_if_equal() with multiple solutions", {
   grader <- grade_this({
-    pass_if_equal(y = .solution_all, message = "YES")
+    pass_if_equal(y = .solution_all, message = "YES {.solution_code} - {.solution_label} - {.solution}")
     fail("NO")
   })
 
   solution_code <-
-    "# one ----
+    "# first ----
 1
-# two ----
+# alt ----
 2
-# three ----
+# alt ----
 3"
 
   # correct
-  expect_graded(
+  grade_first <- expect_graded(
     grader(mock_this_exercise(1, !!solution_code)),
     is_correct = TRUE,
-    msg = "YES"
+    msg = "YES 1 - first - 1"
   )
+  expect_equal(grade_first$solution_label, "first")
+  expect_equal(grade_first$solution_index, 1L)
 
-  expect_graded(
+  grade_alt <- expect_graded(
     grader(mock_this_exercise(2, !!solution_code)),
     is_correct = TRUE,
-    msg = "YES"
+    msg = "YES 2 - alt - 2"
   )
+  expect_equal(grade_alt$solution_label, "alt")
+  expect_equal(grade_alt$solution_index, 2L)
 
-  expect_graded(
+  grade_alt_1 <- expect_graded(
     grader(mock_this_exercise(3, !!solution_code)),
     is_correct = TRUE,
-    msg = "YES"
+    msg = "YES 3 - alt - 3"
   )
+  expect_equal(grade_alt_1$solution_label, "alt")
+  expect_equal(grade_alt_1$solution_index, 3L)
 
   # incorrect
   expect_graded(

--- a/tests/testthat/test-gradethis_exercise_checker.R
+++ b/tests/testthat/test-gradethis_exercise_checker.R
@@ -296,3 +296,41 @@ test_that("pass_if() and fail_if() work in grade_this()", {
   )
   expect_match(err$error$message, "does not accept functions or formulas")
 })
+
+test_that("multiple solutions are prepared correctly with unique code header names", {
+  ex <- mock_this_exercise("1", "# one ----\n1\n# two ----\n2\n# three ----\n3")
+
+  solution_labels <- c("one", "two", "three")
+
+  expect_s3_class(ex$.solution_code_all, "gradethis_solutions")
+  expect_named(ex$.solution_code_all, solution_labels)
+  expect_equal(ex$.solution_code, ex$.solution_code_all[["three"]])
+  expect_s3_class(ex$.solution_all, "gradethis_solutions_env")
+  expect_setequal(
+    names(ex$.solution_all),
+    c(".solution_labels", solution_labels)
+  )
+  expect_equal(unname(get(".solution_labels", ex$.solution_all)), solution_labels)
+  expect_equal(ex$.solution_all[["three"]], ex$.solution)
+})
+
+test_that("multiple solutions are prepared correctly with non-unique code header names", {
+  ex <- mock_this_exercise("1", "# one ----\n1\n# one ----\n2\n# one ----\n3")
+
+  # we make the env names unique because they have to be
+  solution_labels_exp <- c("one", "one_1", "one_2")
+
+  expect_s3_class(ex$.solution_code_all, "gradethis_solutions")
+  expect_named(ex$.solution_code_all, c("one", "one", "one"))
+  expect_equal(ex$.solution_code, ex$.solution_code_all[[3]])
+  expect_s3_class(ex$.solution_all, "gradethis_solutions_env")
+  expect_setequal(
+    names(ex$.solution_all),
+    c(".solution_labels", solution_labels_exp)
+  )
+  solution_labels <- get(".solution_labels", ex$.solution_all)
+  expect_equal(names(solution_labels), solution_labels_exp)
+  expect_equal(unname(solution_labels), c("one", "one", "one"))
+
+  expect_equal(ex$.solution_all[["one_2"]], ex$.solution)
+})


### PR DESCRIPTION
## Technical Details

I restored `get_from_env()` which I used in this branch but not in #305.

`.solution_all` is an environment and needs to be treated differently from `.solution_code_all`, which is a list. To standardize our language, the solution _label_ is the text provided in the code heading by the author. Importantly, these are not required to be unique.

1. For `.solution_code_all` the best practice (for internal code) is to iterate sequentially through the list. The names of each items in the list are the solution labels. Sequential iteration is required because the labels are not guaranteed to be unique.
2. Because `.solution_all` is an environment, we covert the labels into binding _names_ and store the map in `.solution_all[[".solution_labels"]]`.
	* The names of the `.solution_labels` are the binding names in `.solution_all`
	* The values of `.solution_labels` are the labels, e.g. `.solution_labels[[name]]` gives the author's original label
	* You can iterate over the `names(.solution_labels)` which will be in the order provided by the author
	* If only one solution is provided without any code headers, that solution is named and labelled `"solution"`. But `.solution_code_all` won't be named.

I also added a new section to `?pass_if_equal` that describes how multiple solutions are handled with this function (for #292)

## Example

Here's the example from the new section in `?pass_if_equal`. The imagined prompt might be to subset `mtcars` to cars with the same number of cylinders. This gives 3 possible solutions:

``` r
ex_solution <- "
# four cylinders ----
mtcars[mtcars$cyl == 4, ]

# six cylinders ----
mtcars[mtcars$cyl == 6, ]

# eight cylinders ----
mtcars[mtcars$cyl == 8, ]
"
```

In the check chunk, authors call `pass_if_equal(.solution_all)` but they can now also use the label of the matched solution in their feedback messsages.

```r
ex_check <- grade_this({
  pass_if_equal(
    y = .solution_all,
    message = "The cars in your result all have {.solution_label}!"
  )
  
  fail()
})
```

When a student submits a correct answer, the feedback message is customized to the matched solutions.

```r
student_submits <- function(code) {
  submission <- mock_this_exercise(!!code, !!ex_solution)
  ex_check(submission)
}

student_submits("mtcars[mtcars$cyl == 4, ]")
#> <gradethis_graded: [Correct]
#>   The cars in your result all have four cylinders!
#> >
student_submits("mtcars[mtcars$cyl == 6, ]")
#> <gradethis_graded: [Correct]
#>   The cars in your result all have six cylinders!
#> >
```

If the submitted code doesn't match a solution, `pass_if_equal()` yields to the remaining check code, which may also be multiple-solution aware.

```r
student_submits("mtcars[mtcars$cyl < 8, ]")
#> <gradethis_graded: [Incorrect]
#>   Incorrect. In `mtcars[mtcars$cyl < 8, ]`, I expected you to call `==`
#>   where you called `<`. Try it again. Perseverence is the key to
#>   success.
#> >
```