### PR TITLE
Fix `fail(hint = TRUE)` giving multiple hints for multiple solutions

### DIFF
--- a/R/code_feedback.R
+++ b/R/code_feedback.R
@@ -420,7 +420,11 @@ give_code_feedback_.gradethis_graded <- function(
   env = rlang::env_parent(n = 2),
   location = "after"
 ) {
-  solution_code <- get0(".solution_code", envir = env, ifnotfound = NULL)
+  # Use code for multiple solutions if available, otherwise single solution
+  solution_code <-
+    get0(".solution_code_all", envir = env, ifnotfound = NULL) %||%
+    get0(".solution_code", envir = env, ifnotfound = NULL)
+
   user_code <- get0(".user_code", envir = env, ifnotfound = NULL)
 
   if (is.null(solution_code) || !identical(grade$correct, FALSE)) {

--- a/tests/testthat/test-code_feedback.R
+++ b/tests/testthat/test-code_feedback.R
@@ -535,6 +535,23 @@ test_that("give_code_feedback() doesn't add feedback twice", {
     )
 
   expect_equal(str_count(feedback, "I expected"), 1)
+
+  ## Multiple Solutions ----
+  feedback <- expect_exercise_checker(
+    user_code = "sum(1:10)",
+    solution_code = "
+# mean ----
+mean(1:10)
+# median ----
+median(1:10)",
+    check_code = 'grade_this({
+       fail("{maybe_code_feedback()}", hint = TRUE)
+     })',
+    is_correct = FALSE,
+    msg = NULL
+  )$message
+
+  expect_equal(str_count(feedback, "I expected"), 1)
 })
 
 test_that("give_code_feedback() works with pipes", {


### PR DESCRIPTION
Fixes #308

Bascially, `give_code_feedback()` was using `.solution_code` rather than `.solution_code_all`, which only comes into play when calling `faill(hint = TRUE)`. If the feedback provided by `maybe_code_feedback()` in the default fail messages wasn't from the last solution (the one matching `.solution_code`), then the feedback for `.solution_code` would be added into the message.