### PR TITLE
Move `split_code_headers()` to gradethis

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,4 +54,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0

--- a/R/gradethis-package.R
+++ b/R/gradethis-package.R
@@ -22,7 +22,6 @@ NULL
 # @staticimports pkg:learnr
 #   is_AsIs
 #   is_html_tag is_html_chr is_html_any
-#   split_code_headers
 #   str_trim
 #   knitr_engine_caption
 

--- a/R/solutions.R
+++ b/R/solutions.R
@@ -65,3 +65,50 @@ code_standardize_string <- function(code, scalar = TRUE) {
     code
   }
 }
+
+split_code_headers <- function(code, prefix = "section") {
+  if (is.null(code)) {
+    return(NULL)
+  }
+
+  code <- paste(code, collapse = "\n")
+  code <- str_trim(code, character = "[\r\n]")
+  code <- strsplit(code, "\n")[[1]]
+
+  rgx_header <- "^(#+)([ -]*)(.+?)?\\s*----+\\s*$"
+  headers <- regmatches(code, regexec(rgx_header, code, perl = TRUE))
+  lines_headers <- which(vapply(headers, length, integer(1)) > 0)
+
+  if (length(lines_headers) > 0 && max(lines_headers) == length(code)) {
+    # nothing after last heading
+    lines_headers <- lines_headers[-length(lines_headers)]
+  }
+
+  if (!length(lines_headers)) {
+    return(list(paste(code, collapse = "\n")))
+  }
+
+  # header names are 3rd group, so 4th place in match since 1st is the whole match
+  header_names <- vapply(headers[lines_headers], `[[`, character(1), 4)
+  header_names <- str_trim(header_names)
+  if (any(!nzchar(header_names))) {
+    header_names[!nzchar(header_names)] <- sprintf(
+      paste0(prefix, "%02d"),
+      which(!nzchar(header_names))
+    )
+  }
+
+  rgx_header_line <- gsub("[$^]", "(^|\n|$)", rgx_header)
+  sections <- strsplit(paste(code, collapse = "\n"), rgx_header_line, perl = TRUE)[[1]]
+  if (length(sections) > length(header_names)) {
+    header_names <- c(paste0(prefix, "00"), header_names)
+  }
+  names(sections) <- header_names
+
+  # trim leading/trailing new lines from code section
+  sections <- str_trim(sections, character = "[\r\n]")
+  # drop any sections that don't have anything in them
+  sections <- sections[nzchar(str_trim(sections))]
+
+  as.list(sections)
+}

--- a/R/staticimports.R
+++ b/R/staticimports.R
@@ -55,53 +55,6 @@ knitr_engine_caption <- function(engine = NULL) {
   )
 }
 
-split_code_headers <- function(code, prefix = "section") {
-  if (is.null(code)) {
-    return(NULL)
-  }
-
-  code <- paste(code, collapse = "\n")
-  code <- str_trim(code, character = "[\r\n]")
-  code <- strsplit(code, "\n")[[1]]
-
-  rgx_header <- "^(#+)([ -]*)(.+?)?\\s*----+\\s*$"
-  headers <- regmatches(code, regexec(rgx_header, code, perl = TRUE))
-  lines_headers <- which(vapply(headers, length, integer(1)) > 0)
-
-  if (length(lines_headers) > 0 && max(lines_headers) == length(code)) {
-    # nothing after last heading
-    lines_headers <- lines_headers[-length(lines_headers)]
-  }
-
-  if (!length(lines_headers)) {
-    return(list(paste(code, collapse = "\n")))
-  }
-
-  # header names are 3rd group, so 4th place in match since 1st is the whole match
-  header_names <- vapply(headers[lines_headers], `[[`, character(1), 4)
-  header_names <- str_trim(header_names)
-  if (any(!nzchar(header_names))) {
-    header_names[!nzchar(header_names)] <- sprintf(
-      paste0(prefix, "%02d"),
-      which(!nzchar(header_names))
-    )
-  }
-
-  rgx_header_line <- gsub("[$^]", "(^|\n|$)", rgx_header)
-  sections <- strsplit(paste(code, collapse = "\n"), rgx_header_line, perl = TRUE)[[1]]
-  if (length(sections) > length(header_names)) {
-    header_names <- c(paste0(prefix, "00"), header_names)
-  }
-  names(sections) <- header_names
-
-  # trim leading/trailing new lines from code section
-  sections <- str_trim(sections, character = "[\r\n]")
-  # drop any sections that don't have anything in them
-  sections <- sections[nzchar(str_trim(sections))]
-
-  as.list(sections)
-}
-
 str_trim <- function(x, side = "both", character = "\\s") {
   if (side %in% c("both", "left", "start")) {
     rgx <- sprintf("^%s+", character)

--- a/man/debug_this.Rd
+++ b/man/debug_this.Rd
@@ -28,7 +28,9 @@ to debug an exercise and a submission.
 
 \code{debug_this()} gives you a few ways to see the objects that are
 available inside \code{\link[=grade_this]{grade_this()}} for you to use when grading exercise
-submissions. Suppose we have this example exercise:\if{html}{\out{<div class="sourceCode markdown">}}\preformatted{```\{r example-setup\}
+submissions. Suppose we have this example exercise:
+
+\if{html}{\out{<div class="sourceCode markdown">}}\preformatted{```\{r example-setup\}
 x <- 1
 ```
 
@@ -56,10 +58,12 @@ paste("\\\out{\n<blockquote>", gradethis::debug_this(submission)$message, "</blo
 
 The first method is the most straight-forward.
 Inside the \verb{*-check} or \verb{*-error-check} chunks for your exercise,
-simply call \code{debug_this()}:\preformatted{```\{r example-check\}
+simply call \code{debug_this()}:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{```\{r example-check\}
 debug_this()
 ```
-}
+}\if{html}{\out{</div>}}
 
 Every time you submit code for feedback via \strong{Submit Answer},
 the debug information will be printed.
@@ -69,7 +73,9 @@ the debug information will be printed.
 
 On the other hand, if you want to debug a specific submission,
 such as a case where a submission isn't matching any of your current grading conditions,
-you can call \code{debug_this()} wherever you like inside \code{\link[=grade_this]{grade_this()}}.\preformatted{```\{r example-check\}
+you can call \code{debug_this()} wherever you like inside \code{\link[=grade_this]{grade_this()}}.
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{```\{r example-check\}
 grade_this(\{
   pass_if_equal(3, "Good work?")
   
@@ -79,7 +85,7 @@ grade_this(\{
   \}
 \})
 ```
-}
+}\if{html}{\out{</div>}}
 }
 
 \subsection{Debug default fail condition}{
@@ -91,24 +97,28 @@ During development of a tutorial,
 you may want to have this default \code{fail()} return the debugging information
 rather than a failure.
 
-By setting the global option \code{gradethis.fail} to use \code{debug_this()},\preformatted{```\{r setup\}
+By setting the global option \code{gradethis.fail} to use \code{debug_this()},
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{```\{r setup\}
 library(learnr)
 library(gradethis)
 gradethis_setup()
 
 option(gradethis.fail = "\{debug_this()\}")
 ```
-}
+}\if{html}{\out{</div>}}
 
 you can see the values that are available to you during the submission check
-whenever your test submissions pass through your other checks.\preformatted{```\{r example-check\}
+whenever your test submissions pass through your other checks.
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{```\{r example-check\}
 grade_this(\{
   pass_if_equal(3, "Good work?")
   
   fail()
 \})
 ```
-}
+}\if{html}{\out{</div>}}
 
 Don't forget to reset or unset the \code{gradethis.fail} option
 when you're done working on your tutorial.

--- a/man/fail_if_code_feedback.Rd
+++ b/man/fail_if_code_feedback.Rd
@@ -20,14 +20,7 @@ fail_if_code_feedback(
 grading helper functions other than \code{\link[=graded]{graded()}}, \code{message} is a template
 string that will be processed with \code{\link[glue:glue]{glue::glue()}}.}
 
-\item{user_code}{String containing user or solution code. By
-default, when used in \code{\link[=grade_this]{grade_this()}}, \link{.user_code} is retrieved for the
-\link{.user_code}. \code{solution_code} may also be a list containing multiple
-solution variations, so by default in \code{\link[=grade_this]{grade_this()}} \link{.solution_code_all}
-is found and used for \code{solution_code}. You may also use \code{.solution_code} if
-there is only one solution.}
-
-\item{solution_code}{String containing user or solution code. By
+\item{user_code, solution_code}{String containing user or solution code. By
 default, when used in \code{\link[=grade_this]{grade_this()}}, \link{.user_code} is retrieved for the
 \link{.user_code}. \code{solution_code} may also be a list containing multiple
 solution variations, so by default in \code{\link[=grade_this]{grade_this()}} \link{.solution_code_all}
@@ -38,16 +31,7 @@ there is only one solution.}
   Arguments passed on to \code{\link[=graded]{graded}}
   \describe{
     \item{\code{correct}}{A logical value of whether or not the checked code is correct.}
-    \item{\code{type}}{The \code{type} and \code{location} of the feedback object
-provided to \pkg{learnr}. See
-\url{https://rstudio.github.io/learnr/exercises.html#Custom_checking} for more
-details.
-
-\code{type} may be one of "auto", "success", "info", "warning", "error", or
-"custom".
-
-\code{location} may be one of "append", "prepend", or "replace".}
-    \item{\code{location}}{The \code{type} and \code{location} of the feedback object
+    \item{\code{type,location}}{The \code{type} and \code{location} of the feedback object
 provided to \pkg{learnr}. See
 \url{https://rstudio.github.io/learnr/exercises.html#Custom_checking} for more
 details.

--- a/man/grade_this.Rd
+++ b/man/grade_this.Rd
@@ -42,7 +42,9 @@ evaluate the grade-checking \code{expr} and return a final grade via \code{\link
 \description{
 \code{grade_this()} allows instructors to write custom logic to evaluate, grade
 and give feedback to students. To use \code{grade_this()}, call it directly in
-your \verb{*-check} chunk:\preformatted{```\{r example-check\}
+your \verb{*-check} chunk:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{```\{r example-check\}
 grade_this(\{
   # custom checking code appears here
   if (identical(.result, .solution)) \{
@@ -51,7 +53,7 @@ grade_this(\{
   fail("Try again!")
 \})
 ```
-}
+}\if{html}{\out{</div>}}
 
 \code{grade_this()} makes available a number of objects based on the exercise and
 the student's submission that can be used to evaluate the student's submitted

--- a/man/grade_this_code.Rd
+++ b/man/grade_this_code.Rd
@@ -56,15 +56,19 @@ success message (\code{correct}). If the student code does not match the solutio
 a customizable incorrect message (\code{incorrect}) can also be provided.
 
 In most cases, to use \code{grade_this_code()}, ensure that your exercise has a
-\code{-solution} chunk:\preformatted{```\{r example-solution\}
+\code{-solution} chunk:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{```\{r example-solution\}
 sqrt(log(1))
 ```
-}
+}\if{html}{\out{</div>}}
 
-Then, call \code{grade_this_code()} in your exercise's \code{-check} or \code{-code-check} chunk:\preformatted{```\{r example-check\}
+Then, call \code{grade_this_code()} in your exercise's \code{-check} or \code{-code-check} chunk:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{```\{r example-check\}
 grade_this_code()
 ```
-}
+}\if{html}{\out{</div>}}
 
 If \code{grade_this_code()} is called in a \code{-code-check} chunk and returns
 feedback, either passing or failing feedback, then the user's code is not

--- a/man/graded.Rd
+++ b/man/graded.Rd
@@ -131,7 +131,9 @@ The immediate return behavior can be helpful when you have to perform
 complicated or long-running tests to determine if a student's code
 submission is correct. We recommend that you perform the easiest tests
 first, progressing to the most complicated tests. By taking advantage of
-early grade returns, you can simplify your checking code:\preformatted{```\{r\}
+early grade returns, you can simplify your checking code:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{```\{r\}
 grade_this(\{
   # is the answer a tibble?
   if (!inherits(.result, "tibble")) \{
@@ -152,7 +154,7 @@ grade_this(\{
   pass()
 \})
 ```
-}
+}\if{html}{\out{</div>}}
 
 Notice that it's important to choose a final fallback grade as the last
 value in your \code{\link[=grade_this]{grade_this()}} checking code. This last value is the default

--- a/man/gradethis-package.Rd
+++ b/man/gradethis-package.Rd
@@ -6,9 +6,9 @@
 \alias{gradethis-package}
 \title{gradethis: Automated Feedback for Student Exercises in 'learnr' Tutorials}
 \description{
-\if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
+\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Pairing with the 'learnr' R package, 'gradethis' provides multiple methods to grade 'learnr' exercises. To learn more about 'learnr' tutorials, please visit <https://rstudio.github.io/learnr/>.
+Pairing with the 'learnr' R package, 'gradethis' provides multiple methods to grade 'learnr' exercises. To learn more about 'learnr' tutorials, please visit \url{https://rstudio.github.io/learnr/}.
 }
 \seealso{
 Useful links:

--- a/man/gradethis_setup.Rd
+++ b/man/gradethis_setup.Rd
@@ -118,11 +118,13 @@ them with \code{gradethis_setup()}.
 }
 \description{
 To use \pkg{gradethis} in your \pkg{learnr} tutorial, you only need to call
-\code{library(gradethis)} in your tutorial's setup chunk.\preformatted{```\{r setup\}
+\code{library(gradethis)} in your tutorial's setup chunk.
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{```\{r setup\}
 library(learnr)
 library(gradethis)
 ```
-}
+}\if{html}{\out{</div>}}
 
 Use \code{gradethis_setup()} to change the default options suggested by gradethis.
 This function also describes in detail each of the global options available

--- a/man/pass_if_equal.Rd
+++ b/man/pass_if_equal.Rd
@@ -130,7 +130,9 @@ When your exercise has multiple solutions with \strong{different results},
 \code{pass_if_equal()} can compare the student's \link{.result} to each of the
 solutions in \link{.solution_all}, returning a passing grade when the result
 matches any of the values returned by the set of solutions. You can opt into
-this behavior by calling\if{html}{\out{<div class="sourceCode r">}}\preformatted{pass_if_equal(.solution_all)
+this behavior by calling
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{pass_if_equal(.solution_all)
 }\if{html}{\out{</div>}}
 
 Note that this causes \code{pass_if_equal()} to evaluate each of the solutions in
@@ -140,7 +142,9 @@ Here's a small example. Suppose an exercise asks students to filter \code{mtcars
 to include only cars with the same number of cylinders. Students are free to
 pick cars with 4, 6, or 8 cylinders, and so your \code{-solution} chunk would
 include this code (ignoring the \code{ex_solution} variable, the chunk would
-contain the code in the string below):\if{html}{\out{<div class="sourceCode r">}}\preformatted{ex_solution <- "
+contain the code in the string below):
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{ex_solution <- "
 # four cylinders ----
 mtcars[mtcars$cyl == 4, ]
 
@@ -153,7 +157,9 @@ mtcars[mtcars$cyl == 8, ]
 }\if{html}{\out{</div>}}
 
 In the \code{-check} chunk, you'd call \code{\link[=grade_this]{grade_this()}} and ask \code{pass_if_equal()} to
-compare the student's \link{.result} to \link{.solution_all} (all the solutions).\if{html}{\out{<div class="sourceCode r">}}\preformatted{ex_check <- grade_this(\{
+compare the student's \link{.result} to \link{.solution_all} (all the solutions).
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{ex_check <- grade_this(\{
   pass_if_equal(
     y = .solution_all,
     message = "The cars in your result all have \{.solution_label\}!"
@@ -164,7 +170,9 @@ compare the student's \link{.result} to \link{.solution_all} (all the solutions)
 }\if{html}{\out{</div>}}
 
 What happens when a student submits one of these solutions? This function
-below mocks the process of a student submitting an attempt.\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits <- function(code) \{
+below mocks the process of a student submitting an attempt.
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits <- function(code) \{
   withr::local_seed(42)
   submission <- mock_this_exercise(!!code, !!ex_solution)
   ex_check(submission)
@@ -172,15 +180,23 @@ below mocks the process of a student submitting an attempt.\if{html}{\out{<div c
 }\if{html}{\out{</div>}}
 
 If they submit code that returns one of the three possible solutions, they
-receive positive feedback.\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits("mtcars[mtcars$cyl == 4, ]")
-}\if{html}{\out{</div>}}\preformatted{## <gradethis_graded: [Correct]
+receive positive feedback.
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits("mtcars[mtcars$cyl == 4, ]")
+}\if{html}{\out{</div>}}
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## <gradethis_graded: [Correct]
 ##   The cars in your result all have four cylinders!
 ## >
-}\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits("mtcars[mtcars$cyl == 6, ]")
-}\if{html}{\out{</div>}}\preformatted{## <gradethis_graded: [Correct]
+}\if{html}{\out{</div>}}
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits("mtcars[mtcars$cyl == 6, ]")
+}\if{html}{\out{</div>}}
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## <gradethis_graded: [Correct]
 ##   The cars in your result all have six cylinders!
 ## >
-}
+}\if{html}{\out{</div>}}
 
 Notice that the solution label appears in the feedback message. When
 \code{pass_if_equal()} picks a solution as correct, three variables are made
@@ -192,12 +208,16 @@ available for use in the glue string provided to \code{message}:
 }
 
 If the student submits incorrect code, \code{pass_if_equal()} defers to later
-grading code.\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits("mtcars[mtcars$cyl < 8, ]")
-}\if{html}{\out{</div>}}\preformatted{## <gradethis_graded: [Incorrect]
+grading code.
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{student_submits("mtcars[mtcars$cyl < 8, ]")
+}\if{html}{\out{</div>}}
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## <gradethis_graded: [Incorrect]
 ##   Incorrect. In `mtcars[mtcars$cyl < 8, ]`, I expected you to call `==`
 ##   where you called `<`. Please try again.
 ## >
-}
+}\if{html}{\out{</div>}}
 
 Here, because \code{\link[=fail]{fail()}} provides \code{\link[=code_feedback]{code_feedback()}} by default, and because
 \code{\link[=code_feedback]{code_feedback()}} is also aware of the multiple solutions for this exercise,

--- a/tests/testthat/test-solutions.R
+++ b/tests/testthat/test-solutions.R
@@ -85,3 +85,41 @@ runif(2 - 1)'
     "# but maybe this one would work, too\nrunif(2 - 1)"
   )
 })
+
+test_that("split_code_headers()", {
+  target <- list(one = "1", two = "2")
+
+  # No whitespace after dashes
+  expect_equal(
+    split_code_headers(
+      "# one ----
+1
+# two ----
+2"
+    ),
+    target
+  )
+
+
+  # Whitespace after first header
+  expect_equal(
+    split_code_headers(
+      "# one ----
+1
+# two ----
+2"
+    ),
+    target
+  )
+
+  # Whitespace after subsequent headers
+  expect_equal(
+    split_code_headers(
+      "# one ----
+1
+# two ----
+2"
+    ),
+    target
+  )
+})


### PR DESCRIPTION
Previously, `split_code_headers()` was a staticexport from learnr, but after rstudio/learnr#698 it will no longer be used by learnr, so it's being moved here.