### PR TITLE
Change "your R code" to "your code" in error feedback message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@
 * A new `vignette("multiple_solutions")` describes how gradethis can be used to provide feedback for exercises with more than one solution (#312).
 * `gradethis_error_checker()` gains the `hint` argument from `fail()` which follows the global `gradethis.fail.hint` option. When `FALSE`, the error feedback won't include code feedback hints (thanks @cswclui, #315).
 * `gradethis_exercise_checker()` can now be configure to evaluate solution code for non-R exercise engines by providing a function of `code` and `envir` to the `solution_eval_fn` argument. In addition to evaluation R exercise solutions, gradethis will now also evaluate SQL exercise solutions (#316).
+* Feedback for error messages are now slightly more generic and refer to _your code_ instead of _your R code_ (@Laura-Puckett #318).
 
 ### Breaking changes
 

--- a/R/gradethis_error_checker.R
+++ b/R/gradethis_error_checker.R
@@ -58,7 +58,7 @@ gradethis_error_checker <- function(
     )
     if (is.null(msg) || length(msg) < 1) {
       msg <-
-        "An error occurred with your R code. Check your syntax and try again." #nocov
+        "An error occurred with your code. Check your syntax and try again." #nocov
     }
     fail(msg, hint = FALSE, encourage = TRUE)
   }

--- a/R/gradethis_setup.R
+++ b/R/gradethis_setup.R
@@ -215,7 +215,7 @@ gradethis_default_options <- list(
   allow_partial_matching = NULL,
 
   # Default error checker message
-  error_checker.message = "An error occurred with your R code:\n\n```\n{.error$message}\n```\n\n\n"
+  error_checker.message = "An error occurred with your code:\n\n```\n{.error$message}\n```\n\n\n"
 )
 
 # Legacy Options ----------------------------------------------------------


### PR DESCRIPTION
Addresses #317 by removing references to `R` in the feedback message for code errors. 