### PR TITLE
Disable code feedback for non-R exercise engines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -63,4 +63,5 @@
 * Errors in the grading code are now returned as _neutral_ grades rather than failing grades. The feedback message and type can be changed with two new arguments to `gradethis_setup()`: `grading_problem.message` and `grading_problem.type` (#256).
 
 ### Bug fixes
-* Added a `NEWS.md` file to track changes to the package.
+
+* Code feedback is now disabled for non-R exercise engines (#321).

--- a/R/code_feedback.R
+++ b/R/code_feedback.R
@@ -424,10 +424,14 @@ give_code_feedback_.gradethis_graded <- function(
   solution_code <-
     get0(".solution_code_all", envir = env, ifnotfound = NULL) %||%
     get0(".solution_code", envir = env, ifnotfound = NULL)
-
   user_code <- get0(".user_code", envir = env, ifnotfound = NULL)
+  engine <- tolower(get0(".engine", envir = env, ifnotfound = "r"))
 
-  if (is.null(solution_code) || !identical(grade$correct, FALSE)) {
+  is_not_r_ex <- !identical(engine, "r")
+  is_missing_solution <- is.null(solution_code)
+  is_correct <- identical(grade$correct, TRUE)
+
+  if (is_not_r_ex || is_missing_solution || is_correct) {
     signal_grade(grade)
   }
 

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -150,10 +150,13 @@ grade_this <- function(
     # Turn the grading code into a function defined in the `check_env`
     do_grade_this <- rlang::new_function(NULL, body = expr, env = check_env)
 
+    # Disable code feedback if not R code
+    engine <- tolower(get0(".engine", check_env, ifnotfound = "r"))
+    maybe_code_feedback <- identical(engine, "r") && maybe_code_feedback
+
     # make sure fail calls can get code feed back (or not) if they want
     with_maybe_code_feedback(
       maybe_code_feedback,
-
       # capture all pass/fail calls and errors thrown
       eval_gradethis(do_grade_this())
     )

--- a/R/graded.R
+++ b/R/graded.R
@@ -258,10 +258,10 @@ fail <- function(
   user_provided_message <- !missing(message)
 
   this_fail_grade <- function() {
-    if (user_provided_hint && !user_provided_message) {
+    if (user_provided_hint && identical(hint, FALSE) && !user_provided_message) {
       # allow hint = FALSE, provided by the user, to override the default message
       with_maybe_code_feedback(
-        isTRUE(hint),
+        FALSE,
         graded(message = glue_message_with_env(env, message), correct = FALSE, ...)
       )
     } else {

--- a/tests/testthat/test-grade_this.R
+++ b/tests/testthat/test-grade_this.R
@@ -43,3 +43,33 @@ test_that("grade_this() can find things in the parent of the check env", {
   expect_true(found$from_setup)
   expect_true(found$from_user)
 })
+
+test_that("grade_this() doesn't include code feedback for a non-R exercise", {
+  ex <- mock_this_exercise(
+    "1 + 1",
+    .solution_code = "1 + 2",
+    .engine = "python",
+    .result = 2
+  )
+
+  # Doesn't have code feedback as a Python exercise
+  grade_py <- grade_this(fail(), maybe_code_feedback = TRUE)(ex)
+  expect_false(grade_py$correct)
+  expect_no_match(grade_py$message, "I expected")
+
+  # Even if we ask for a hint
+  grade_py <- grade_this(fail(hint = TRUE), maybe_code_feedback = TRUE)(ex)
+  expect_false(grade_py$correct)
+  expect_no_match(grade_py$message, "I expected")
+
+  # Does have code feedback as an R exercise
+  ex$.engine <- "r"
+  grade_r <- grade_this(fail(), maybe_code_feedback = TRUE)(ex)
+  expect_false(grade_r$correct)
+  expect_match(grade_r$message, "I expected")
+
+  # Even if we turn of maybe_code_feedback but ask for a hint
+  grade_r <- grade_this(fail(hint = TRUE), maybe_code_feedback = FALSE)(ex)
+  expect_false(grade_r$correct)
+  expect_match(grade_r$message, "I expected")
+})


### PR DESCRIPTION
- Disable `maybe_code_feedback` when engine isn't R
- Disable `give_code_feedback()` when engine isn't R
- Ensure that we only disable maybe code feedback in `fail()` if we're turning off hints
- Test that non-R engine hints are disabled

## Demo

``` r
ex <- mock_this_exercise(
  "1 + 1",
  .solution_code = "1 + 2",
  .engine = "python",
  .result = 2
)
```

Doesn’t have code feedback as a Python exercise

``` r
grade_this(fail(), maybe_code_feedback = TRUE)(ex)
#> <gradethis_graded: [Incorrect]
#>   Incorrect. Don't give up now, try it one more time.
#> >
```

Even if we ask for a hint

``` r
grade_this(fail(hint = TRUE), maybe_code_feedback = TRUE)(ex)
#> <gradethis_graded: [Incorrect]
#>   Incorrect. Don't give up now, try it one more time.
#> >
```

Does have code feedback as an R exercise

``` r
ex$.engine <- "r"
grade_this(fail(), maybe_code_feedback = TRUE)(ex)
#> <gradethis_graded: [Incorrect]
#>   Incorrect. In `1 + 1`, I expected `2` where you wrote `1`. Try it
#>   again. You get better each time.
#> >
```

Even if we turn of `maybe_code_feedback` but ask for a hint

``` r
grade_this(fail(hint = TRUE), maybe_code_feedback = FALSE)(ex)
#> <gradethis_graded: [Incorrect]
#>   Incorrect. Try it again; next time's the charm! In `1 + 1`, I
#>   expected `2` where you wrote `1`.
#> >
```