### PR TITLE
Add more operators to list of infixes

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,12 +1,11 @@
 linters: linters_with_defaults(
     object_usage_linter = NULL,
     line_length_linter(120),
-    T_and_F_symbol_linter,
-    absolute_path_linter,
-    nonportable_path_linter,
-    semicolon_linter,
-    undesirable_operator_linter,
-    object_length_linter(42)
+    absolute_path_linter(),
+    nonportable_path_linter(),
+    undesirable_operator_linter(),
+    object_length_linter(42),
+    backport_linter(r_version = "oldrel-4", except = c("str2expression", "str2lang"))
   )
 exclusions: list(
     "R/staticimports.R",

--- a/NEWS.md
+++ b/NEWS.md
@@ -65,3 +65,4 @@
 ### Bug fixes
 
 * Code feedback is now disabled for non-R exercise engines (#321).
+* More operators were added to our list of infixes (#327).

--- a/R/utils-assertions.R
+++ b/R/utils-assertions.R
@@ -1,16 +1,22 @@
-.pipes <- c("%>%")
+.pipes <- c("%>%", "|>")
 
 is_pipe <- function(x) {
   if (is.character(x)) x <- parse(text = x)[[1]]
   ifelse(is.call(x), as.character(x[[1]]) %in% .pipes, FALSE)
 }
 
+# From `?base::Syntax` but lightly organized into groups
 .infixes_assign <- c("<-", "<<-", "->", "->>", "=")
 .infixes_comp <- c("==", "!=", ">", ">=", "<", "<=")
+.infixes_operator <- c(
+  "$", "@", "[", "[[", "^", "-", "+", ":", "*", "/",
+  "!", "&", "&&", "|", "||", "~", "?"
+)
 .infixes <- c(
-  "+", "-", "*", "/", "^", "$", "[", "[[", "!", "%%", "%/%", "%in%",
+  "%%", "%/%", "%in%",
   .infixes_assign,
-  .infixes_comp
+  .infixes_comp,
+  .infixes_operator
 )
 
 is_infix <- function(x, infix_vals = .infixes) {

--- a/R/utils-assertions.R
+++ b/R/utils-assertions.R
@@ -6,7 +6,7 @@ is_pipe <- function(x) {
 }
 
 # From `?base::Syntax` but lightly organized into groups
-.infixes_assign <- c("<-", "<<-", "->", "->>", "=")
+.infixes_assign <- c("<-", "<<-", "->", "->>", "=", ":=")
 .infixes_comp <- c("==", "!=", ">", ">=", "<", "<=")
 .infixes_operator <- c(
   "$", "@", "[", "[[", "^", "-", "+", ":", "*", "/",

--- a/R/utils-assertions.R
+++ b/R/utils-assertions.R
@@ -19,7 +19,7 @@ is_pipe <- function(x) {
   .infixes_operator
 )
 
-is_infix <- function(x, infix_vals = .infixes) {
+is_infix <- function(x, infix_vals = .infixes, exact = FALSE) {
 
   tryCatch({
     if (is.character(x)) {
@@ -32,7 +32,12 @@ is_infix <- function(x, infix_vals = .infixes) {
       return(FALSE)
     }
 
-    any(as.character(out[[1]]) %in% infix_vals)
+    call_text <- as.character(out[[1]])
+
+    is_known_infix <- any(call_text %in% infix_vals)
+    if (exact) return(is_known_infix)
+
+    is_known_infix || any(grepl("^%.*%$", call_text))
   }, error = function(e) {
     # x is not an infix
     FALSE
@@ -40,5 +45,5 @@ is_infix <- function(x, infix_vals = .infixes) {
 }
 
 is_infix_assign <- function(x) {
-  is_infix(x, infix_vals = .infixes_assign)
+  is_infix(x, infix_vals = .infixes_assign, exact = TRUE)
 }

--- a/tests/testthat/_snaps/detect_mistakes.md
+++ b/tests/testthat/_snaps/detect_mistakes.md
@@ -26,3 +26,10 @@
     Output
       I expected you to call `~` where you called `<-`.
 
+---
+
+    Code
+      detect_mistakes(quote(1 - 4), quote(1:4))
+    Output
+      I expected you to call `:` where you called `-`.
+

--- a/tests/testthat/_snaps/detect_mistakes.md
+++ b/tests/testthat/_snaps/detect_mistakes.md
@@ -1,0 +1,28 @@
+# detect_mistakes works with infix operators
+
+    Code
+      detect_mistakes(quote(TRUE & FALSE), quote(TRUE | FALSE))
+    Output
+      I expected you to call `|` where you called `&`.
+
+---
+
+    Code
+      detect_mistakes(quote(2^2), quote(2 * 2))
+    Output
+      I expected you to call `*` where you called `^`.
+
+---
+
+    Code
+      detect_mistakes(quote(obj$value), quote(obj@value))
+    Output
+      I expected you to call `@` where you called `$`.
+
+---
+
+    Code
+      detect_mistakes(quote(y <- m * x + b), quote(y ~ m * x + b))
+    Output
+      I expected you to call `~` where you called `<-`.
+

--- a/tests/testthat/_snaps/detect_mistakes.md
+++ b/tests/testthat/_snaps/detect_mistakes.md
@@ -33,3 +33,10 @@
     Output
       I expected you to call `:` where you called `-`.
 
+---
+
+    Code
+      detect_mistakes(quote(a %like% b), quote(a %LIKE% b))
+    Output
+      I expected you to call `%LIKE%` where you called `%like%`.
+

--- a/tests/testthat/test-detect_mistakes.R
+++ b/tests/testthat/test-detect_mistakes.R
@@ -229,6 +229,7 @@ test_that("detect_mistakes works with infix operators", {
   expect_snapshot(detect_mistakes(quote(2^2), quote(2*2)))
   expect_snapshot(detect_mistakes(quote(obj$value), quote(obj@value)))
   expect_snapshot(detect_mistakes(quote(y <- m * x + b), quote(y ~ m * x + b)))
+  expect_snapshot(detect_mistakes(quote(1-4), quote(1:4)))
 
   #   # surplus
   #   user <-     quote(b(1 + 2))

--- a/tests/testthat/test-detect_mistakes.R
+++ b/tests/testthat/test-detect_mistakes.R
@@ -230,6 +230,7 @@ test_that("detect_mistakes works with infix operators", {
   expect_snapshot(detect_mistakes(quote(obj$value), quote(obj@value)))
   expect_snapshot(detect_mistakes(quote(y <- m * x + b), quote(y ~ m * x + b)))
   expect_snapshot(detect_mistakes(quote(1-4), quote(1:4)))
+  expect_snapshot(detect_mistakes(quote(a %like% b), quote(a %LIKE% b)))
 
   #   # surplus
   #   user <-     quote(b(1 + 2))

--- a/tests/testthat/test-detect_mistakes.R
+++ b/tests/testthat/test-detect_mistakes.R
@@ -1,4 +1,3 @@
-context("Check code with calls")
 a <<- function(x) x
 b <<- function(x) x
 

--- a/tests/testthat/test-detect_mistakes.R
+++ b/tests/testthat/test-detect_mistakes.R
@@ -1,3 +1,5 @@
+local_edition(3)
+
 a <<- function(x) x
 b <<- function(x) x
 
@@ -221,6 +223,12 @@ test_that("detect_mistakes works with infix operators", {
     detect_mistakes(user, solution),
     wrong_call(this = user, that = solution)
   )
+
+  # other operators
+  expect_snapshot(detect_mistakes(quote(TRUE & FALSE), quote(TRUE | FALSE)))
+  expect_snapshot(detect_mistakes(quote(2^2), quote(2*2)))
+  expect_snapshot(detect_mistakes(quote(obj$value), quote(obj@value)))
+  expect_snapshot(detect_mistakes(quote(y <- m * x + b), quote(y ~ m * x + b)))
 
   #   # surplus
   #   user <-     quote(b(1 + 2))


### PR DESCRIPTION
Adds more operators to our list of infixes, increasing coverage to include everything listed in `?base::Syntax`.

Fixes #326

``` r
pkgload::load_all()

ex <- mock_this_exercise(
  .user_code = "TRUE | FALSE",
  .solution_code = "FALSE & FALSE"
) 

grade_this({
  fail_if_code_feedback()
  pass()
})(ex)
#> <gradethis_graded: [Incorrect]
#>   I expected you to call `&` where you called `|`.
#> >
```