### PR TITLE
If `waldo::compare()` errors, fall back to `identical()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,4 +55,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/R/graded.R
+++ b/R/graded.R
@@ -569,6 +569,8 @@ grade_if_equal <- function(
       # https://github.com/brodieG/diffobj/issues/152#issuecomment-788083359
       # waldo::compare() calls diffobj::ses() — these functions try hard to create
       # a usable diff to describe the differences.
+      # We're engaging in some off-label usage of these functions,
+      # so they will sometimes error when we give them unusual inputs.
       # If these functions throw an error, we fall back to `identical()`.
       # Since we aren't (currently)
       # interested in reporting the differences between `x` and `y`, we mark

--- a/R/graded.R
+++ b/R/graded.R
@@ -565,9 +565,8 @@ grade_if_equal <- function(
 
   compare_msg <- tryCatch(
     {
-      time_limit <- knitr::opts_chunk$get("exercise.timelimit") %||%
-        gradethis_default_learnr_options$exercise.timelimit
-      time_limit <- time_limit * 0.8
+      time_limit <- gradethis_settings$diff.timelimit() %||%
+        (knitr::opts_chunk$get("exercise.timelimit") * 0.8)
       # If `waldo::compare()` takes too long to evaluate,
       # just skip to the fallback (`identical()`)
       setTimeLimit(elapsed = time_limit, transient = TRUE)

--- a/R/graded.R
+++ b/R/graded.R
@@ -568,21 +568,12 @@ grade_if_equal <- function(
     error = function(e) {
       # https://github.com/brodieG/diffobj/issues/152#issuecomment-788083359
       # waldo::compare() calls diffobj::ses() — these functions try hard to create
-      # a usable diff to describe the differences. These filters below cover
-      # cases where the diff description throws an error, but we know they only
-      # arise when a difference has occurred. Since we aren't (currently)
+      # a usable diff to describe the differences.
+      # If these functions throw an error, we fall back to `identical()`.
+      # Since we aren't (currently)
       # interested in reporting the differences between `x` and `y`, we mark
-      # these as known to be different
-      if (grepl("Exceeded buffer for finding fake snake", e$message, fixed = TRUE)) {
-        "different"
-      } else if (grepl("reached theoretically unreachable branch 2", e$message, fixed = TRUE)) {
-        "different"
-      } else {
-        warning(
-          "Error in grade_if_equal(): ", deparse(e$call), ": ", e$message, call. = FALSE
-        )
-        capture_graded(grade_grading_problem(error = e))
-      }
+      # these cases as simply "different" if they aren't identical.
+      if (!identical(x, y)) "different"
     }
   )
 

--- a/R/graded.R
+++ b/R/graded.R
@@ -574,15 +574,13 @@ grade_if_equal <- function(
       waldo::compare(x, y, tolerance = tolerance)
     },
     error = function(e) {
-      # https://github.com/brodieG/diffobj/issues/152#issuecomment-788083359
-      # waldo::compare() calls diffobj::ses() — these functions try hard to create
-      # a usable diff to describe the differences.
-      # We're engaging in some off-label usage of these functions,
-      # so they will sometimes error when we give them unusual inputs.
-      # If these functions throw an error, we fall back to `identical()`.
-      # Since we aren't (currently)
-      # interested in reporting the differences between `x` and `y`, we mark
-      # these cases as simply "different" if they aren't identical.
+      # waldo::compare() takes into account a lot of the things we'd have to
+      # think about in comparing two objects, but its goal is to create a
+      # readable diff. Since we're engaging in some off-label usage of these
+      # functions, they will sometimes error or take longer than desired when we
+      # give them unusual inputs. In these cases, we fall back to `identical()`.
+      # Since we aren't (currently) interested in reporting the differences
+      # between `x` and `y`, we mark them "different" if they aren't identical.
       if (!identical(x, y)) "different"
     }
   )

--- a/R/graded.R
+++ b/R/graded.R
@@ -564,14 +564,9 @@ grade_if_equal <- function(
   local_options_waldo_compare()
 
   compare_msg <- tryCatch(
-    {
-      time_limit <- gradethis_settings$diff.timelimit() %||%
-        (knitr::opts_chunk$get("exercise.timelimit") * 0.8)
-      # If `waldo::compare()` takes too long to evaluate,
-      # just skip to the fallback (`identical()`)
-      setTimeLimit(elapsed = time_limit, transient = TRUE)
+    try_with_timelimit(
       waldo::compare(x, y, tolerance = tolerance)
-    },
+    ),
     error = function(e) {
       # waldo::compare() takes into account a lot of the things we'd have to
       # think about in comparing two objects, but its goal is to create a

--- a/R/graded.R
+++ b/R/graded.R
@@ -564,7 +564,15 @@ grade_if_equal <- function(
   local_options_waldo_compare()
 
   compare_msg <- tryCatch(
-    waldo::compare(x, y, tolerance = tolerance),
+    {
+      time_limit <- knitr::opts_chunk$get("exercise.timelimit") %||%
+        gradethis_default_learnr_options$exercise.timelimit
+      time_limit <- time_limit * 0.8
+      # If `waldo::compare()` takes too long to evaluate,
+      # just skip to the fallback (`identical()`)
+      setTimeLimit(elapsed = time_limit, transient = TRUE)
+      waldo::compare(x, y, tolerance = tolerance)
+    },
     error = function(e) {
       # https://github.com/brodieG/diffobj/issues/152#issuecomment-788083359
       # waldo::compare() calls diffobj::ses() — these functions try hard to create

--- a/R/gradethis_setup.R
+++ b/R/gradethis_setup.R
@@ -81,6 +81,14 @@
 #' @param fail_code_feedback Deprecated. Use `maybe_code_feedback`.
 #' @inheritParams learnr::tutorial_options
 #' @inheritDotParams learnr::tutorial_options
+#' @param diff.timelimit [pass_if_equal()] and [fail_if_equal()] call
+#'   [waldo::compare()] internally.
+#'   This helps ensure an accurate comparison, but sometimes takes a long time.
+#'   `diff.timelimit` is the time limit in seconds
+#'   for the execution of [waldo::compare()]
+#'   (defaults to 80% of `exercise.timelimit`).
+#'   If the time limit is exceeded,
+#'   `identical()` is used instead of [waldo::compare()].
 #'
 #' @return Invisibly returns the global options as they were prior to setting
 #'   them with `gradethis_setup()`.
@@ -106,6 +114,7 @@ gradethis_setup <- function(
   allow_partial_matching = NULL,
   exercise.checker = gradethis_exercise_checker,
   exercise.timelimit = NULL,
+  diff.timelimit = NULL,
   exercise.error.check.code = NULL,
   fail_code_feedback = NULL # nolint end
 ) {
@@ -215,7 +224,9 @@ gradethis_default_options <- list(
   allow_partial_matching = NULL,
 
   # Default error checker message
-  error_checker.message = "An error occurred with your code:\n\n```\n{.error$message}\n```\n\n\n"
+  error_checker.message = "An error occurred with your code:\n\n```\n{.error$message}\n```\n\n\n",
+
+  diff.timelimit = NULL
 )
 
 # Legacy Options ----------------------------------------------------------

--- a/R/gradethis_setup.R
+++ b/R/gradethis_setup.R
@@ -81,10 +81,10 @@
 #' @param fail_code_feedback Deprecated. Use `maybe_code_feedback`.
 #' @inheritParams learnr::tutorial_options
 #' @inheritDotParams learnr::tutorial_options
-#' @param diff.timelimit [pass_if_equal()] and [fail_if_equal()] call
+#' @param compare_timelimit [pass_if_equal()] and [fail_if_equal()] call
 #'   [waldo::compare()] internally.
 #'   This helps ensure an accurate comparison, but sometimes takes a long time.
-#'   `diff.timelimit` is the time limit in seconds
+#'   `compare_timelimit` is the time limit in seconds
 #'   for the execution of [waldo::compare()]
 #'   (defaults to 80% of `exercise.timelimit`).
 #'   If the time limit is exceeded,
@@ -114,7 +114,7 @@ gradethis_setup <- function(
   allow_partial_matching = NULL,
   exercise.checker = gradethis_exercise_checker,
   exercise.timelimit = NULL,
-  diff.timelimit = NULL,
+  compare_timelimit = NULL,
   exercise.error.check.code = NULL,
   fail_code_feedback = NULL # nolint end
 ) {
@@ -226,7 +226,7 @@ gradethis_default_options <- list(
   # Default error checker message
   error_checker.message = "An error occurred with your code:\n\n```\n{.error$message}\n```\n\n\n",
 
-  diff.timelimit = NULL
+  compare_timelimit = NULL
 )
 
 # Legacy Options ----------------------------------------------------------

--- a/R/utils.R
+++ b/R/utils.R
@@ -81,7 +81,7 @@ local_env_insert_parent <- function(
 
 try_with_timelimit <- function(expr, timelimit = NULL, call = parent.frame()) {
 
-  timelimit <- gradethis_settings$diff.timelimit() %||%
+  timelimit <- gradethis_settings$compare_timelimit() %||%
     ((knitr::opts_chunk$get("exercise.timelimit") %||% 30) * 0.8)
 
   setTimeLimit(elapsed = timelimit, transient = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -79,6 +79,32 @@ local_env_insert_parent <- function(
   invisible(child)
 }
 
+try_with_timelimit <- function(expr, timelimit = NULL, call = parent.frame()) {
+
+  timelimit <- gradethis_settings$diff.timelimit() %||%
+    ((knitr::opts_chunk$get("exercise.timelimit") %||% 30) * 0.8)
+
+  setTimeLimit(elapsed = timelimit, transient = TRUE)
+  on.exit(setTimeLimit(cpu = Inf, elapsed = Inf, transient = FALSE), add = TRUE)
+
+  tryCatch(
+    expr,
+    error = function(err) {
+      msg_timed_out <- gettext("reached elapsed time limit")
+      timed_out <- grepl(msg_timed_out, conditionMessage(err), fixed = TRUE)
+      if (timed_out) {
+        rlang::abort(
+          msg_timed_out,
+          class = "elapsed_time_limit",
+          call = call,
+          timelimit = timelimit
+        )
+      } else {
+        rlang::cnd_signal(err)
+      }
+    }
+  )
+}
 
 # nocov start
 env_rls <- function(env, show_contents = TRUE) {

--- a/man/gradethis_setup.Rd
+++ b/man/gradethis_setup.Rd
@@ -23,6 +23,7 @@ gradethis_setup(
   allow_partial_matching = NULL,
   exercise.checker = gradethis_exercise_checker,
   exercise.timelimit = NULL,
+  diff.timelimit = NULL,
   exercise.error.check.code = NULL,
   fail_code_feedback = NULL
 )
@@ -107,6 +108,15 @@ partial matching is allowed in \code{grade_this_code()}. Sets the
 \item{exercise.timelimit}{Number of seconds to limit execution time to
 (defaults to \code{30}).}
 
+\item{diff.timelimit}{\code{\link[=pass_if_equal]{pass_if_equal()}} and \code{\link[=fail_if_equal]{fail_if_equal()}} call
+\code{\link[waldo:compare]{waldo::compare()}} internally.
+This helps ensure an accurate comparison, but sometimes takes a long time.
+\code{diff.timelimit} is the time limit in seconds
+for the execution of \code{\link[waldo:compare]{waldo::compare()}}
+(defaults to 80\% of \code{exercise.timelimit}).
+If the time limit is exceeded,
+\code{identical()} is used instead of \code{\link[waldo:compare]{waldo::compare()}}.}
+
 \item{exercise.error.check.code}{A string containing R code to use for checking
 code when an exercise evaluation error occurs (e.g., \code{"gradethis::grade_code()"}).}
 
@@ -156,6 +166,7 @@ when gradethis is loaded are shown below.\tabular{ll}{
    \code{gradethis.grading_problem.type} \tab \code{"warning"} \cr
    \code{gradethis.allow_partial_matching} \tab \code{NULL} \cr
    \code{gradethis.error_checker.message} \tab \code{"An error occurred with your code:\\n\\n```\\n{.error$message}\\n```\\n\\n\\n"} \cr
+   \code{gradethis.diff.timelimit} \tab \code{NULL} \cr
 }
 }
 

--- a/man/gradethis_setup.Rd
+++ b/man/gradethis_setup.Rd
@@ -23,7 +23,7 @@ gradethis_setup(
   allow_partial_matching = NULL,
   exercise.checker = gradethis_exercise_checker,
   exercise.timelimit = NULL,
-  diff.timelimit = NULL,
+  compare_timelimit = NULL,
   exercise.error.check.code = NULL,
   fail_code_feedback = NULL
 )
@@ -108,10 +108,10 @@ partial matching is allowed in \code{grade_this_code()}. Sets the
 \item{exercise.timelimit}{Number of seconds to limit execution time to
 (defaults to \code{30}).}
 
-\item{diff.timelimit}{\code{\link[=pass_if_equal]{pass_if_equal()}} and \code{\link[=fail_if_equal]{fail_if_equal()}} call
+\item{compare_timelimit}{\code{\link[=pass_if_equal]{pass_if_equal()}} and \code{\link[=fail_if_equal]{fail_if_equal()}} call
 \code{\link[waldo:compare]{waldo::compare()}} internally.
 This helps ensure an accurate comparison, but sometimes takes a long time.
-\code{diff.timelimit} is the time limit in seconds
+\code{compare_timelimit} is the time limit in seconds
 for the execution of \code{\link[waldo:compare]{waldo::compare()}}
 (defaults to 80\% of \code{exercise.timelimit}).
 If the time limit is exceeded,
@@ -166,7 +166,7 @@ when gradethis is loaded are shown below.\tabular{ll}{
    \code{gradethis.grading_problem.type} \tab \code{"warning"} \cr
    \code{gradethis.allow_partial_matching} \tab \code{NULL} \cr
    \code{gradethis.error_checker.message} \tab \code{"An error occurred with your code:\\n\\n```\\n{.error$message}\\n```\\n\\n\\n"} \cr
-   \code{gradethis.diff.timelimit} \tab \code{NULL} \cr
+   \code{gradethis.compare_timelimit} \tab \code{NULL} \cr
 }
 }
 

--- a/tests/testthat/test-graded.R
+++ b/tests/testthat/test-graded.R
@@ -520,6 +520,21 @@ test_that("grade_if_equal() edge cases with diffobj::ses()", {
   expect_null(
     grade_if_equal(a, b, message = "TEST_FAILED", FALSE)
   )
+
+  a <- structure(c(
+    `0` = 0.0160069994947357, `1` = -0.0954295831831162,
+    `2` = -0.060342605088278, `3` = 0.0993515771117325, `4` = 0.101717325946816
+  ), .Dim = 5L, .Dimnames = list(c("0", "1", "2", "3", "4")))
+
+  b <- structure(c(
+    `0` = 1.53731223147442, `1` = -9.16505716890648,
+    `2` = -5.79530379267822, `3` = 9.54172546581079, `4` = 9.76893198393223
+  ), .Dim = 5L, .Dimnames = list(c("0", "1", "2", "3", "4")))
+  # names(lines) <- format(c("", row_idx), align = "right"):
+  # 'names' attribute [11] must be the same length as the vector [3]
+  expect_null(
+    grade_if_equal(a, b, message = "TEST_FAILED", FALSE)
+  )
 })
 
 test_that("praise argument works with passing grades", {

--- a/tests/testthat/test-graded.R
+++ b/tests/testthat/test-graded.R
@@ -521,15 +521,16 @@ test_that("grade_if_equal() edge cases with diffobj::ses()", {
     grade_if_equal(a, b, message = "TEST_FAILED", FALSE)
   )
 
-  a <- structure(c(
-    `0` = 0.0160069994947357, `1` = -0.0954295831831162,
-    `2` = -0.060342605088278, `3` = 0.0993515771117325, `4` = 0.101717325946816
-  ), .Dim = 5L, .Dimnames = list(c("0", "1", "2", "3", "4")))
+  a <- array(1, dim = 5, dimnames = list(letters[1:5]))
+  b <- array(2, dim = 5, dimnames = list(letters[1:5]))
+  # names(lines) <- format(c("", row_idx), align = "right"):
+  # 'names' attribute [11] must be the same length as the vector [3]
+  expect_null(
+    grade_if_equal(a, b, message = "TEST_FAILED", FALSE)
+  )
 
-  b <- structure(c(
-    `0` = 1.53731223147442, `1` = -9.16505716890648,
-    `2` = -5.79530379267822, `3` = 9.54172546581079, `4` = 9.76893198393223
-  ), .Dim = 5L, .Dimnames = list(c("0", "1", "2", "3", "4")))
+  a <- array(1, dim = rep(5, 3), dimnames = rep(list(letters[1:5]), 3))
+  b <- array(2, dim = rep(5, 3), dimnames = rep(list(letters[1:5]), 3))
   # names(lines) <- format(c("", row_idx), align = "right"):
   # 'names' attribute [11] must be the same length as the vector [3]
   expect_null(

--- a/tests/testthat/test-gradethis_setup.R
+++ b/tests/testthat/test-gradethis_setup.R
@@ -52,44 +52,44 @@ test_that("gradethis_setup() sets default learnr options via chunk opts", {
 test_that("gradethis_setup() sets time limit for waldo::compare()", {
   local_knitr_opts_chunk()
 
-  with_options(list(gradethis.diff.timelimit = NULL), {
+  with_options(list(gradethis.compare_timelimit = NULL), {
     with_knitr_opts_chunk(list(exercise.timelimit = NULL), {
       gradethis_setup()
       expect_equal(
-        gradethis_settings$diff.timelimit() %||%
+        gradethis_settings$compare_timelimit() %||%
           (knitr::opts_chunk$get("exercise.timelimit") * 0.8),
         48
       )
     })
   })
 
-  with_options(list(gradethis.diff.timelimit = NULL), {
+  with_options(list(gradethis.compare_timelimit = NULL), {
     with_knitr_opts_chunk(list(exercise.timelimit = NULL), {
       gradethis_setup(exercise.timelimit = 10)
       expect_equal(
-        gradethis_settings$diff.timelimit() %||%
+        gradethis_settings$compare_timelimit() %||%
           (knitr::opts_chunk$get("exercise.timelimit") * 0.8),
         8
       )
     })
   })
 
-  with_options(list(gradethis.diff.timelimit = NULL), {
+  with_options(list(gradethis.compare_timelimit = NULL), {
     with_knitr_opts_chunk(list(exercise.timelimit = NULL), {
-      gradethis_setup(diff.timelimit = 10)
+      gradethis_setup(compare_timelimit = 10)
       expect_equal(
-        gradethis_settings$diff.timelimit() %||%
+        gradethis_settings$compare_timelimit() %||%
           (knitr::opts_chunk$get("exercise.timelimit") * 0.8),
         10
       )
     })
   })
 
-  with_options(list(gradethis.diff.timelimit = NULL), {
+  with_options(list(gradethis.compare_timelimit = NULL), {
     with_knitr_opts_chunk(list(exercise.timelimit = NULL), {
-      gradethis_setup(exercise.timelimit = 10, diff.timelimit = 10)
+      gradethis_setup(exercise.timelimit = 10, compare_timelimit = 10)
       expect_equal(
-        gradethis_settings$diff.timelimit() %||%
+        gradethis_settings$compare_timelimit() %||%
           (knitr::opts_chunk$get("exercise.timelimit") * 0.8),
         10
       )

--- a/tests/testthat/test-gradethis_setup.R
+++ b/tests/testthat/test-gradethis_setup.R
@@ -48,3 +48,51 @@ test_that("gradethis_setup() sets default learnr options via chunk opts", {
     expect_equal(knitr::opts_chunk$get("exercise.timelimit"), 42)
   })
 })
+
+test_that("gradethis_setup() sets time limit for waldo::compare()", {
+  local_knitr_opts_chunk()
+
+  with_options(list(gradethis.diff.timelimit = NULL), {
+    with_knitr_opts_chunk(list(exercise.timelimit = NULL), {
+      gradethis_setup()
+      expect_equal(
+        gradethis_settings$diff.timelimit() %||%
+          (knitr::opts_chunk$get("exercise.timelimit") * 0.8),
+        48
+      )
+    })
+  })
+
+  with_options(list(gradethis.diff.timelimit = NULL), {
+    with_knitr_opts_chunk(list(exercise.timelimit = NULL), {
+      gradethis_setup(exercise.timelimit = 10)
+      expect_equal(
+        gradethis_settings$diff.timelimit() %||%
+          (knitr::opts_chunk$get("exercise.timelimit") * 0.8),
+        8
+      )
+    })
+  })
+
+  with_options(list(gradethis.diff.timelimit = NULL), {
+    with_knitr_opts_chunk(list(exercise.timelimit = NULL), {
+      gradethis_setup(diff.timelimit = 10)
+      expect_equal(
+        gradethis_settings$diff.timelimit() %||%
+          (knitr::opts_chunk$get("exercise.timelimit") * 0.8),
+        10
+      )
+    })
+  })
+
+  with_options(list(gradethis.diff.timelimit = NULL), {
+    with_knitr_opts_chunk(list(exercise.timelimit = NULL), {
+      gradethis_setup(exercise.timelimit = 10, diff.timelimit = 10)
+      expect_equal(
+        gradethis_settings$diff.timelimit() %||%
+          (knitr::opts_chunk$get("exercise.timelimit") * 0.8),
+        10
+      )
+    })
+  })
+})


### PR DESCRIPTION
Avoids errors when in `grade_if_equal()` resulting in ungraded code when `.result` or `.solution` cannot be properly handled by `waldo::compare()`.

Closes #328:

``` r
.result <- structure(c(`0` = 0.0160069994947357, `1` = -0.0954295831831162, 
                       `2` = -0.060342605088278, `3` = 0.0993515771117325, `4` = 0.101717325946816
), .Dim = 5L, .Dimnames = list(c("0", "1", "2", "3", "4")))

.solution <- structure(c(`0` = 1.53731223147442, `1` = -9.16505716890648, 
                         `2` = -5.79530379267822, `3` = 9.54172546581079, `4` = 9.76893198393223
), .Dim = 5L, .Dimnames = list(c("0", "1", "2", "3", "4")))

pass_if_equal()
#> NULL
```

<sup>Created on 2022-12-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>