### PR TITLE
Include simplified implementation of `call_fn()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,6 @@ Imports:
     purrr,
     rlang,
     rstudioapi,
-    testthat,
     utils,
     waldo,
     withr
@@ -45,7 +44,8 @@ Suggests:
     DBI,
     knitr,
     rmarkdown,
-    spelling
+    spelling,
+    testthat
 VignetteBuilder: 
     knitr
 Remotes: 

--- a/R/call_standarise_formals.R
+++ b/R/call_standarise_formals.R
@@ -102,7 +102,7 @@ call_standardise_formals_recursive <- function( # nolint
 
 call_fn <- function(code, env) {
   if (rlang::is_quosure(code) || rlang::is_formula(code)) {
-    code <- get_expr(code)
+    code <- rlang::get_expr(code)
   }
   stopifnot(rlang::is_call(code))
 

--- a/R/code_feedback.R
+++ b/R/code_feedback.R
@@ -414,7 +414,7 @@ give_code_feedback_.function <- function(x, ..., env = NULL, location = "after")
 
 #' @export
 give_code_feedback_.gradethis_graded <- function(
-  grade,
+  x,
   ...,
   env = rlang::env_parent(n = 2),
   location = "after"
@@ -428,10 +428,10 @@ give_code_feedback_.gradethis_graded <- function(
 
   is_not_r_ex <- !identical(engine, "r")
   is_missing_solution <- is.null(solution_code)
-  is_correct <- identical(grade$correct, TRUE)
+  is_correct <- identical(x$correct, TRUE)
 
   if (is_not_r_ex || is_missing_solution || is_correct) {
-    signal_grade(grade)
+    signal_grade(x)
   }
 
   # What about correct grades with differences??
@@ -443,18 +443,18 @@ give_code_feedback_.gradethis_graded <- function(
 
   # If there isn't any feedback or if the feedback message has already been
   # added to the grade message, then just re-throw the grade
-  if (identical(feedback, "") || grepl(feedback, grade$message, fixed = TRUE)) {
-    signal_grade(grade)
+  if (identical(feedback, "") || grepl(feedback, x$message, fixed = TRUE)) {
+    signal_grade(x)
   }
 
   before <- identical(location, "before")
-  grade$message <- paste0(
+  x$message <- paste0(
     if (before) feedback,
-    grade$message,
+    x$message,
     if (!before) feedback
   )
 
-  signal_grade(grade)
+  signal_grade(x)
 }
 
 #' @export

--- a/R/detect_mistakes_helpers.R
+++ b/R/detect_mistakes_helpers.R
@@ -112,7 +112,6 @@ detect_name_problems <- function(
           remaining_user_names,
           remaining_solution_names,
           matched_user_names,
-          matched_solution_names,
           enclosing_call,
           enclosing_arg
         )
@@ -230,7 +229,6 @@ detect_pmatches_argument_name <- function(
   remaining_user_names,
   remaining_solution_names,
   matched_user_names,
-  matched_solution_names,
   enclosing_call,
   enclosing_arg
 ) {


### PR DESCRIPTION
Removes dependency on deprecated `rlang::call_fn()`.

Closes #334.

This PR also includes a few miscellaneous change to fix R CMD check issues.