### PR TITLE
`call_standardise_formals()` now attempts to standardise formals of S3 methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gradethis
 Title: Automated Feedback for Student Exercises in 'learnr' Tutorials
-Version: 0.2.12.9000
+Version: 0.2.12.9001
 Authors@R: c(
     person("Garrick", "Aden-Buie", , "garrick@posit.co", role = "aut",
            comment = c(ORCID = "0000-0002-7111-0077")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,6 @@ Imports:
     learnr (>= 0.10.1.9008),
     lifecycle,
     magrittr,
-    methods,
     purrr,
     rlang,
     rstudioapi,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Imports:
     learnr (>= 0.10.1.9008),
     lifecycle,
     magrittr,
+    methods,
     purrr,
     rlang,
     rstudioapi,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gradethis
 Title: Automated Feedback for Student Exercises in 'learnr' Tutorials
-Version: 0.2.12.9001
+Version: 0.2.12.9002
 Authors@R: c(
     person("Garrick", "Aden-Buie", , "garrick@posit.co", role = "aut",
            comment = c(ORCID = "0000-0002-7111-0077")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gradethis 0.2.12.9001
 
+* `call_standardise_formals()` now attempts to standardize the arguments of calls to S3 generics (#339).
+
 # gradethis 0.2.12.9000
 
 * New functions: `user_object_get()`, `user_object_exists()` and `user_object_list()` can be used to interact with objects created by the student's code. `solution_object_get()`, `solution_object_exists()` and `solution_object_list()` do the same for objects created by the solution code (#333).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# gradethis 0.2.12.9001
+
 # gradethis 0.2.12.9000
 
 * New functions: `user_object_get()`, `user_object_exists()` and `user_object_list()` can be used to interact with objects created by the student's code. `solution_object_get()`, `solution_object_exists()` and `solution_object_list()` do the same for objects created by the solution code (#333).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
-# gradethis 0.2.12.9001
+# gradethis 0.2.12.9002
 
 * `call_standardise_formals()` now attempts to standardize the arguments of calls to S3 generics (#339).
+
+# gradethis 0.2.12.9001
+
 * `pass_if()` and `fail_if()` now produce more informative error messages if their `cond` argument is invalid (#341).
 
 # gradethis 0.2.12.9000

--- a/R/call_standarise_formals.R
+++ b/R/call_standarise_formals.R
@@ -111,20 +111,19 @@ call_fn <- function(code, env = parent.frame()) {
   fn <- rlang::eval_bare(head, env)
   stopifnot(rlang::is_function(fn))
 
-  fn_is_s3_generic <- isS3stdGeneric(fn)
-  fn_name <- names(fn_is_s3_generic) %||% head
+  try_is_s3 <- purrr::possibly(utils::isS3stdGeneric, otherwise = FALSE)
+  fn_is_s3_generic <- try_is_s3(fn)
 
   if (fn_is_s3_generic) {
-    tryCatch(
-      fn <- resolve_s3_generic(fn_name, arg = code[[2]], env = env) %||% fn,
-      error = function(e) return(fn)
-    )
+    fn_name <- names(fn_is_s3_generic) %||% head
+    try_get_s3_method <- purrr::possibly(get_s3_method, otherwise = NULL)
+    fn <- try_get_s3_method(fn_name, arg = code[[2]], env = env) %||% fn
   }
 
   fn
 }
 
-resolve_s3_generic <- function(fn_name, arg, env = parent.frame()) {
+get_s3_method <- function(fn_name, arg, env = parent.frame()) {
   class <- expand_class(arg, env)
 
   while (length(class) > 0) {
@@ -166,40 +165,4 @@ expand_class <- function(arg, env) {
 
   class <- unique(append(class, "default"))
   class
-}
-
-# Backport of `utils::isS3stdGeneric()` from R 4.1.0
-#
-#  File src/library/utils/R/objects.R
-#  Part of the R package, https://www.R-project.org
-#
-#  Copyright (C) 1995-2020 The R Core Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  A copy of the GNU General Public License is available at
-#  https://www.R-project.org/Licenses/
-isS3stdGeneric <- function(f) {
-  bdexpr <- body(if(methods::is(f, "traceable")) f@original else f)
-  ## protect against technically valid but bizarre
-  ## function(x) { { { UseMethod("gen")}}} by
-  ## repeatedly consuming the { until we get to the first non { expr
-  while(is.call(bdexpr) && bdexpr[[1L]] == "{")
-    bdexpr <- bdexpr[[2L]]
-
-  ## We only check if it is a "standard" s3 generic. i.e. the first non-{
-  ## expression is a call to UseMethod. This will return FALSE if any
-  ## work occurs before the UseMethod call ("non-standard" S3 generic)
-  ret <- is.call(bdexpr) && bdexpr[[1L]] == "UseMethod"
-  if(ret)
-    names(ret) <- bdexpr[[2L]] ## arg passed to UseMethod naming generic
-  ret
 }

--- a/R/call_standarise_formals.R
+++ b/R/call_standarise_formals.R
@@ -112,7 +112,7 @@ call_fn <- function(code, env = parent.frame()) {
   stopifnot(rlang::is_function(fn))
 
   fn_is_s3_generic <- isS3stdGeneric(fn)
-  fn_name <- names(fn_is_s3_generic)
+  fn_name <- names(fn_is_s3_generic) %||% head
 
   if (fn_is_s3_generic) {
     tryCatch(

--- a/R/call_standarise_formals.R
+++ b/R/call_standarise_formals.R
@@ -146,7 +146,7 @@ resolve_s3_generic <- function(fn, code, env = parent.frame()) {
   s3_method <- NULL
 
   while(length(class) > 0) {
-    try(s3_method <- getS3method(fn_name, class[[1]]), silent = TRUE)
+    try(s3_method <- utils::getS3method(fn_name, class[[1]]), silent = TRUE)
 
     if (!is.null(s3_method)) {
       fn <- s3_method

--- a/tests/testthat/test-call_standarise_formals.R
+++ b/tests/testthat/test-call_standarise_formals.R
@@ -1,13 +1,13 @@
-test_that("Standarize call with formals primitive function", {
+test_that("Standarize call with formals S3 function", {
   user <- rlang::get_expr(quote(mean(1:3, na.rm = TRUE)))
   user_stand <- call_standardise_formals(user)
 
-  expect_equal(user_stand, quote(mean(x = 1:3, na.rm = TRUE)))
+  expect_equal(user_stand, quote(mean(x = 1:3, trim = 0, na.rm = TRUE)))
 
   user <- quote(mean(1:3, 0, TRUE))
   user_stand <- call_standardise_formals(user)
 
-  expect_equal(user_stand, quote(mean(x = 1:3, 0, TRUE)))
+  expect_equal(user_stand, quote(mean(x = 1:3, trim = 0, na.rm = TRUE)))
 })
 
 test_that("Standarize call with formals user function", {

--- a/tests/testthat/test-call_standarise_formals.R
+++ b/tests/testthat/test-call_standarise_formals.R
@@ -27,6 +27,50 @@ test_that("Standarize call with formals user function", {
   )
 })
 
+test_that("Standarize call with formals user S3 function", {
+  my_func <- function(x, ...) {
+    UseMethod("my_func")
+  }
+
+  my_func.numeric <- function(x, y, z = 100, ...) {
+    x + y + z
+  }
+
+  my_func.character <- function(x, a, b = 3.14, c = "s", ...) {
+    paste(x, a, b, c)
+  }
+
+  user_numeric <- rlang::get_expr(quote(my_func(x = 1, 20)))
+  user_numeric_stand <- call_standardise_formals(
+    user_numeric,
+    env = rlang::env(
+      my_func = my_func,
+      my_func.numeric = my_func.numeric,
+      my_func.character = my_func.character
+    )
+  )
+
+  testthat::expect_equal(
+    user_numeric_stand,
+    quote(my_func(x = 1, y = 20, z = 100))
+  )
+
+  user_character <- rlang::get_expr(quote(my_func(x = "1", 20)))
+  user_character_stand <- call_standardise_formals(
+    user_character,
+    env = rlang::env(
+      my_func = my_func,
+      my_func.numeric = my_func.numeric,
+      my_func.character = my_func.character
+    )
+  )
+
+  testthat::expect_equal(
+    user_character_stand,
+    quote(my_func(x = "1", a = 20, b = 3.14, c = "s"))
+  )
+})
+
 test_that("Standarize call with ... and kwargs", {
   a <- quote(vapply(list(1:3, 4:6), mean, numeric(1), 0, TRUE))
   b <- quote(vapply(list(1:3, 4:6), mean, numeric(1), trim = 0, TRUE))

--- a/tests/testthat/test-detect_mistakes.R
+++ b/tests/testthat/test-detect_mistakes.R
@@ -727,19 +727,16 @@ test_that("detect_mistakes handles argument names correctly", {
     )
   )
 
-  # This user code looks correct (and runs!) but na.rm is an argument passed to
+  # This user code looks correct (and runs!) but invalid is an argument passed to
   # ... that does not appear in the solution, and so should be flagged wrong.
-  user <-     quote(mean(1:10, cut = 1, na.rm = TRUE))
-  solution <- quote(mean(1:10, TRUE, cut = 1))
+  user <-     quote(mean(1:10, cut = 1, invalid = TRUE))
+  solution <- quote(mean(1:10, cut = 1))
   expect_equal(
     detect_mistakes(user, solution),
-    # message_wrong_value(this = quote(1),
-    #             this_name = "cut",
-    #             that = quote(TRUE))
     message_surplus_argument(
       submitted_call = quote(mean()),
       submitted = quote(TRUE),
-      submitted_name = "na.rm"
+      submitted_name = "invalid"
     )
   )
 


### PR DESCRIPTION
``` r
.user_code <- quote(mean(1:3))
gradethis:::call_standardise_formals(.user_code)
#> mean(x = 1:3, trim = 0, na.rm = FALSE)
```

<sup>Created on 2023-03-30 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>