### PR TITLE
Add default arguments to `gradethis_equal()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gradethis
 Title: Automated Feedback for Student Exercises in 'learnr' Tutorials
-Version: 0.2.12.9004
+Version: 0.2.12.9005
 Authors@R: c(
     person("Garrick", "Aden-Buie", , "garrick@posit.co", role = "aut",
            comment = c(ORCID = "0000-0002-7111-0077")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# gradethis (development version)
+
 # gradethis 0.2.12.9004
 
 * Add `fail_if_not_equal()` (#346).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-# gradethis (development version)
+# gradethis 0.2.12.9005
+
+* `gradethis_equal()` now has default arguments of `x = .result` and `y = .solution` (#347).
+    * `gradethis_equal.default()` now has a default argument of `tolerance = sqrt(.Machine$double.eps)`.
 
 # gradethis 0.2.12.9004
 

--- a/R/gradethis_equal.R
+++ b/R/gradethis_equal.R
@@ -9,7 +9,13 @@
 #' @examples
 #' gradethis_equal(mtcars[mtcars$cyl == 6, ], mtcars[mtcars$cyl == 6, ])
 #' gradethis_equal(mtcars[mtcars$cyl == 6, ], mtcars[mtcars$cyl == 4, ])
-gradethis_equal <- function(x, y, ...) {
+gradethis_equal <- function(x = .result, y = .solution, ...) {
+  if (is_placeholder(x) || is_placeholder(y)) {
+    x <- resolve_placeholder(x)
+    y <- resolve_placeholder(y)
+    return(gradethis_equal(x, y, ...))
+  }
+
   UseMethod("gradethis_equal")
 }
 

--- a/R/gradethis_equal.R
+++ b/R/gradethis_equal.R
@@ -24,10 +24,10 @@ gradethis_equal <- function(x = .result, y = .solution, ...) {
 #' @inheritParams waldo::compare
 #' @export
 gradethis_equal.default <- function(
-    x,
-    y,
-    tolerance = sqrt(.Machine$double.eps),
-    ...
+  x,
+  y,
+  tolerance = sqrt(.Machine$double.eps),
+  ...
 ) {
   local_options_waldo_compare()
 

--- a/R/gradethis_equal.R
+++ b/R/gradethis_equal.R
@@ -17,7 +17,12 @@ gradethis_equal <- function(x, y, ...) {
 #'   The default comparison method, which uses [waldo::compare]
 #' @inheritParams waldo::compare
 #' @export
-gradethis_equal.default <- function(x, y, tolerance, ...) {
+gradethis_equal.default <- function(
+    x,
+    y,
+    tolerance = sqrt(.Machine$double.eps),
+    ...
+) {
   local_options_waldo_compare()
 
   tryCatch(

--- a/man/gradethis_equal.Rd
+++ b/man/gradethis_equal.Rd
@@ -5,9 +5,9 @@
 \alias{gradethis_equal.default}
 \title{Compare the values of two objects to check whether they are equal}
 \usage{
-gradethis_equal(x, y, ...)
+gradethis_equal(x = .result, y = .solution, ...)
 
-\method{gradethis_equal}{default}(x, y, tolerance, ...)
+\method{gradethis_equal}{default}(x, y, tolerance = sqrt(.Machine$double.eps), ...)
 }
 \arguments{
 \item{x, y}{Two objects to compare}
@@ -15,9 +15,10 @@ gradethis_equal(x, y, ...)
 \item{...}{Additional arguments passed to methods}
 
 \item{tolerance}{If non-\code{NULL}, used as threshold for ignoring small
-floating point difference when comparing numeric vectors. Setting to
-any non-\code{NULL} value will cause integer and double vectors to be compared
-based on their values, rather than their types.
+floating point difference when comparing numeric vectors. Using any
+non-\code{NULL} value will cause integer and double vectors to be compared
+based on their values, not their types, and will ignore the difference
+between \code{NaN} and \code{NA_real_}.
 
 It uses the same algorithm as \code{\link[=all.equal]{all.equal()}}, i.e., first we generate
 \code{x_diff} and \code{y_diff} by subsetting \code{x} and \code{y} to look only locations

--- a/man/pass_if_equal.Rd
+++ b/man/pass_if_equal.Rd
@@ -69,9 +69,10 @@ the student's submission against a specific value, \code{y}.}
 \pkg{gradethis} will not need to use this argument.}
 
 \item{tolerance}{If non-\code{NULL}, used as threshold for ignoring small
-floating point difference when comparing numeric vectors. Setting to
-any non-\code{NULL} value will cause integer and double vectors to be compared
-based on their values, rather than their types.
+floating point difference when comparing numeric vectors. Using any
+non-\code{NULL} value will cause integer and double vectors to be compared
+based on their values, not their types, and will ignore the difference
+between \code{NaN} and \code{NA_real_}.
 
 It uses the same algorithm as \code{\link[=all.equal]{all.equal()}}, i.e., first we generate
 \code{x_diff} and \code{y_diff} by subsetting \code{x} and \code{y} to look only locations


### PR DESCRIPTION
- `gradethis_equal()` now has default values of `x = .result` and `y = .solution`.
- `gradethis_equal.default()` now has a default value of `tolerance = sqrt(.Machine$double.eps)`.
	- This fixes a bug where `gradethis_equal()` would fail if called without explicitly setting a `tolerance` argument.