### PR TITLE
Standardize arguments to functions defined by input or setup code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gradethis
 Title: Automated Feedback for Student Exercises in 'learnr' Tutorials
-Version: 0.2.12.9005
+Version: 0.2.12.9006
 Authors@R: c(
     person("Garrick", "Aden-Buie", , "garrick@posit.co", role = "aut",
            comment = c(ORCID = "0000-0002-7111-0077")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# gradethis (development version)
+
 # gradethis 0.2.12.9005
 
 * `gradethis_equal()` now has default arguments of `x = .result` and `y = .solution` (#347).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gradethis (development version)
+# gradethis 0.2.12.9006
+
+* `code_feedback()` now standardizes arguments to functions defined within student and solution code before comparing code. It also now successfully standardizes arguments passed through `...` by mapping functions into functions defined by setup code (#349).
 
 # gradethis 0.2.12.9005
 

--- a/R/call_standarise_formals.R
+++ b/R/call_standarise_formals.R
@@ -185,7 +185,7 @@ dot_args_standardise <- function(code, fn, mappers, dot_args, env) {
     n_args <- 1
   }
 
-  return(as.list(call_standardise_formals(call))[-seq_len(n_args + 1)])
+  return(as.list(call_standardise_formals(call, env))[-seq_len(n_args + 1)])
 }
 
 mapping_function_list <- function() {

--- a/R/call_standarise_formals.R
+++ b/R/call_standarise_formals.R
@@ -86,10 +86,19 @@ call_standardise_keep_partials <- function(code, env = rlang::caller_env()) {
 }
 
 call_standardise_formals_recursive <- function( # nolint
-  code, env = rlang::current_env(), include_defaults = TRUE
+  code,
+  env = rlang::current_env(),
+  include_defaults = TRUE
 ) {
   if (is.list(code)) {
-    return(lapply(code, call_standardise_formals_recursive))
+    return(
+      purrr::map(
+        code,
+        call_standardise_formals_recursive,
+        env = env,
+        include_defaults = include_defaults
+      )
+    )
   }
 
   # `code` must be parsed call
@@ -97,9 +106,14 @@ call_standardise_formals_recursive <- function( # nolint
     return(code)
   }
 
-  code <- purrr::map(as.list(code), call_standardise_formals_recursive)
+  code <- purrr::map(
+    as.list(code),
+    call_standardise_formals_recursive,
+    env = env,
+    include_defaults = include_defaults
+  )
   code <- as.call(code)
-  call_standardise_formals(code)
+  call_standardise_formals(code, env = env, include_defaults = include_defaults)
 }
 
 call_standardise_passed_arguments <- function(code, fn, fmls, env) {

--- a/R/code_feedback.R
+++ b/R/code_feedback.R
@@ -137,6 +137,8 @@
 #' @param solution_env Environment used to standardize formals of the solution code.
 #'   Defaults to retrieving [.envir_solution] from the calling environment.
 #'   If not found, the [parent.frame()] will be used.
+#' @param env Environment used to standardize formals of the user and solution code.
+#'   Defaults to retrieving [.envir_result] and [.envir_solution] from [parent.frame()].
 #' @param ... Ignored in `code_feedback()` and `maybe_code_feedback()`. In
 #'   `give_code_feedback()`, `...` are passed to `maybe_code_feedback()`.
 #' @param allow_partial_matching A logical. If `FALSE`, the partial matching of

--- a/R/code_feedback.R
+++ b/R/code_feedback.R
@@ -131,9 +131,12 @@
 #'   solution variations, so by default in [grade_this()] [.solution_code_all]
 #'   is found and used for `solution_code`. You may also use `.solution_code` if
 #'   there is only one solution.
-#' @param env Environment used to standardize formals of the user and solution
-#'   code. Defaults to retrieving [.envir_prep] from the calling environment. If
-#'   not found, the [parent.frame()] will be used.
+#' @param user_env Environment used to standardize formals of the user code.
+#'   Defaults to retrieving [.envir_result] from the calling environment.
+#'   If not found, the [parent.frame()] will be used.
+#' @param solution_env Environment used to standardize formals of the solution code.
+#'   Defaults to retrieving [.envir_solution] from the calling environment.
+#'   If not found, the [parent.frame()] will be used.
 #' @param ... Ignored in `code_feedback()` and `maybe_code_feedback()`. In
 #'   `give_code_feedback()`, `...` are passed to `maybe_code_feedback()`.
 #' @param allow_partial_matching A logical. If `FALSE`, the partial matching of

--- a/R/code_feedback.R
+++ b/R/code_feedback.R
@@ -160,7 +160,8 @@
 code_feedback <- function(
   user_code = .user_code,
   solution_code = .solution_code_all,
-  env = .envir_prep,
+  user_env = .envir_result,
+  solution_env = .envir_solution,
   ...,
   allow_partial_matching = getOption("gradethis.allow_partial_matching", TRUE)
 ) {
@@ -173,17 +174,25 @@ code_feedback <- function(
       throw_grade = FALSE
     )
 
-  env <- resolve_placeholder_parent(env, default = parent.frame())
+  user_env <- resolve_placeholder_parent(user_env, default = parent.frame())
+  solution_env <- resolve_placeholder_parent(solution_env, default = parent.frame())
   user_code <- resolve_placeholder_parent(user_code, default = NULL)
   solution_code <- resolve_placeholder_parent(solution_code, default = NULL)
 
   if (inherits(solution_code, "gradethis_solutions") || is.list(solution_code)) {
-    solution_code <- solution_code_closest(user_code, solution_code)
+    # pass env?
+    solution_code <- solution_code_closest(
+      user_code,
+      solution_code,
+      user_env,
+      solution_env
+    )
   }
 
   user_expr <- to_expr(user_code, "user_code")
   solution_expr <- to_expr(solution_code, "solution_code")
-  checkmate::assert_environment(env, null.ok = FALSE, .var.name = "env")
+  checkmate::assert_environment(user_env, null.ok = FALSE, .var.name = "user_env")
+  checkmate::assert_environment(solution_env, null.ok = FALSE, .var.name = "solution_env")
 
   if (identical(user_expr, solution_expr)) {
     # identical! return early
@@ -194,7 +203,8 @@ code_feedback <- function(
   detect_mistakes(
     user = user_expr,
     solution = solution_expr,
-    env = new.env(parent = env),
+    user_env = new.env(parent = user_env),
+    solution_env = new.env(parent = solution_env),
     allow_partial_matching = isTRUE(allow_partial_matching)
   )
 }
@@ -219,12 +229,27 @@ with_maybe_code_feedback <- function(val, expr) {
   )
 }
 
-solution_code_closest <- function(user_code, solution_code_all) {
-  closest_solution <- solution_code_closest_which(user_code, solution_code_all)
+solution_code_closest <- function(
+  user_code,
+  solution_code_all,
+  user_env,
+  solution_env
+) {
+  closest_solution <- solution_code_closest_which(
+    user_code,
+    solution_code_all,
+    user_env,
+    solution_env
+  )
   unlist(solution_code_all[closest_solution])
 }
 
-solution_code_closest_which <- function(user_code, solution_code_all) {
+solution_code_closest_which <- function(
+  user_code,
+  solution_code_all,
+  user_env,
+  solution_env
+) {
   # If there's no solution code or only one solution,
   # we don't need to find the closest match
   if (length(solution_code_all) < 2) {
@@ -234,19 +259,19 @@ solution_code_closest_which <- function(user_code, solution_code_all) {
   # Convert from list to character vector
   solution_code_all <- unlist(solution_code_all)
 
-  standardise_code_text <- function(code) {
+  standardise_code_text <- function(code, env) {
     code %>%
       unpipe_all_str() %>%
       rlang::parse_exprs() %>%
-      call_standardise_formals_recursive() %>%
+      call_standardise_formals_recursive(env = env) %>%
       purrr::map_chr(rlang::expr_text) %>%
       paste(collapse = "\n")
   }
 
-  user_code <- standardise_code_text(user_code)
+  user_code <- standardise_code_text(user_code, env = user_env)
 
   solution_code_all <- solution_code_all %>%
-    purrr::map_chr(standardise_code_text)
+    purrr::map_chr(standardise_code_text, env = solution_env)
 
   # Find the index of the solution code that the user code is closest to
   # which.min.last() uses the last index if there is a tie
@@ -294,7 +319,8 @@ which.min.last <- function(x) { # nolint: object_name
 maybe_code_feedback <- function(
   user_code = get0(".user_code", parent.frame()),
   solution_code = get0(".solution_code_all", parent.frame()),
-  env = get0(".envir_prep", parent.frame(), ifnotfound = parent.frame()),
+  user_env = get0(".envir_result", parent.frame(), ifnotfound = parent.frame()),
+  solution_env = get0(".envir_solution", parent.frame(), ifnotfound = parent.frame()),
   ...,
   allow_partial_matching = getOption("gradethis.allow_partial_matching", TRUE),
   default = "",
@@ -337,7 +363,8 @@ maybe_code_feedback <- function(
       code_feedback_val <- code_feedback(
         user_code = user_code,
         solution_code = solution_code,
-        env = env,
+        user_env = user_env,
+        solution_env = solution_env,
         allow_partial_matching = allow_partial_matching
       )
       if (is.null(code_feedback_val)) {

--- a/R/detect_mistakes.R
+++ b/R/detect_mistakes.R
@@ -1,12 +1,14 @@
 detect_mistakes <- function(
   user,
   solution,
-  env = rlang::env_parent(),
+  user_env = rlang::env_parent(),
+  solution_env = rlang::env_parent(),
   enclosing_call = NULL,
   enclosing_arg = NULL,
   allow_partial_matching = TRUE
 ) {
-  force(env)
+  force(user_env)
+  force(solution_env)
 
   if (rlang::is_quosure(user)) {
     user <- rlang::get_expr(user)
@@ -21,7 +23,13 @@ detect_mistakes <- function(
     # and runs `detect_mistakes()` on them recursively.
     return(
       detect_mistakes_expression(
-        user, solution, env, enclosing_call, enclosing_arg, allow_partial_matching
+        user,
+        solution,
+        user_env,
+        solution_env,
+        enclosing_call,
+        enclosing_arg,
+        allow_partial_matching
       )
     )
   }
@@ -34,7 +42,7 @@ detect_mistakes <- function(
     submitted_names <- rlang::names2(user)
   }
   if (is.call(solution)) {
-    solution <- call_standardise_formals(unpipe_all(solution), env = env)
+    solution <- call_standardise_formals(unpipe_all(solution), env = solution_env)
   }
 
   # If the code contains a bare value, then the user and solution value
@@ -72,12 +80,17 @@ detect_mistakes <- function(
   #    argument.
   return_if_not_null(
     detect_missing_argument(
-      submitted, solution_original, env, enclosing_call, enclosing_arg
+      submitted,
+      solution_original,
+      user_env,
+      solution_env,
+      enclosing_call,
+      enclosing_arg
     )
   )
 
   # It is now safe to call call_standardise_formals on student code
-  user <- suppressWarnings(call_standardise_formals(user, env = env))
+  user <- suppressWarnings(call_standardise_formals(user, env = user_env))
   user_names <- real_names(user)
   solution_names <- real_names(solution) # original solution_names was modified above
 
@@ -107,7 +120,8 @@ detect_mistakes <- function(
       solution_names,
       submitted,
       submitted_names,
-      env,
+      user_env,
+      solution_env,
       enclosing_call,
       enclosing_arg,
       allow_partial_matching
@@ -119,7 +133,13 @@ detect_mistakes <- function(
 }
 
 detect_mistakes_expression <- function(
-  user, solution, env, enclosing_call, enclosing_arg, allow_partial_matching
+  user,
+  solution,
+  user_env,
+  solution_env,
+  enclosing_call,
+  enclosing_arg,
+  allow_partial_matching
 ) {
   stopifnot(is.expression(solution))
 
@@ -139,7 +159,8 @@ detect_mistakes_expression <- function(
       detect_mistakes(
         user[[i]],
         solution[[i]],
-        env = env,
+        user_env = user_env,
+        solution_env = solution_env,
         enclosing_call = enclosing_call,
         enclosing_arg = enclosing_arg,
         allow_partial_matching = allow_partial_matching

--- a/R/detect_mistakes_helpers.R
+++ b/R/detect_mistakes_helpers.R
@@ -273,16 +273,21 @@ detect_unnamed_surplus_argument <- function(
 }
 
 detect_missing_argument <- function(
-  submitted, solution_original, env, enclosing_call, enclosing_arg
+  submitted,
+  solution_original,
+  user_env,
+  solution_env,
+  enclosing_call,
+  enclosing_arg
 ) {
   explicit_user <- suppressWarnings(call_standardise_formals(
     unpipe_all(submitted),
-    env = env,
+    env = user_env,
     include_defaults = FALSE
   ))
   explicit_solution <- call_standardise_formals(
     unpipe_all(solution_original),
-    env = env,
+    env = solution_env,
     include_defaults = FALSE
   )
   explicit_user_names <- real_names(explicit_user)
@@ -328,7 +333,8 @@ detect_wrong_arguments <- function(
   solution_names,
   submitted,
   submitted_names,
-  env,
+  user_env,
+  solution_env,
   enclosing_call,
   enclosing_arg,
   allow_partial_matching
@@ -344,11 +350,12 @@ detect_wrong_arguments <- function(
     if (!identical(user[[name]], solution[[name]])) {
       arg_name <- ifelse(name %in% submitted_names, name, "")
       # recover the user submission as provided by only unpiping one level
-      user_submitted <- call_standardise_formals(unpipe(submitted), env = env)
+      user_submitted <- call_standardise_formals(unpipe(submitted), env = user_env)
       res <- detect_mistakes(
         user = user_submitted[[name]],
         solution = solution[[name]],
-        env = env,
+        user_env = user_env,
+        solution_env = solution_env,
         # If too verbose, use user[1]
         enclosing_call = submitted,
         # avoid naming first arguments in messages
@@ -413,7 +420,7 @@ detect_wrong_arguments <- function(
       if (!(name %in% submitted_names)) name <- ""
 
       # find user arg as submitted
-      user_args_submitted <- as.list(call_standardise_formals(unpipe(submitted), env = env))
+      user_args_submitted <- as.list(call_standardise_formals(unpipe(submitted), env = user_env))
       user_args_ignore <- which(names(user_args_submitted) %in% user_named_args_ignore_list)
       user_args_submitted <- user_args_submitted[-c(1, user_args_ignore)]
 
@@ -421,7 +428,8 @@ detect_wrong_arguments <- function(
         # unpipe only one level to detect mistakes in the argument as submitted
         user = user_args_submitted[[i]],
         solution = solution_args[[i]],
-        env = env,
+        user_env = user_env,
+        solution_env = solution_env,
         # If too verbose, use user[1]
         enclosing_call = submitted,
         enclosing_arg = name,

--- a/R/grade_code.R
+++ b/R/grade_code.R
@@ -136,7 +136,8 @@ grade_code <- function(
     message <- code_feedback(
       user_code = user_code,
       solution_code = solution_code_all,
-      env = check_env,
+      user_env = check_env$.envir_result,
+      solution_env = check_env$.envir_solution,
       allow_partial_matching = allow_partial_matching
     )
 

--- a/R/graded.R
+++ b/R/graded.R
@@ -469,6 +469,9 @@ fail_if <- function(
 #'
 #' # Perfect!
 #' grader(mock_this_exercise(runif(n = 5), !!.solution_code))
+#'
+#' @param env Environment used to standardize formals of the user and solution code.
+#'   Defaults to retrieving [.envir_result] and [.envir_solution] from [parent.frame()].
 #' @inheritParams code_feedback
 #' @inheritParams graded
 #' @inheritDotParams graded

--- a/R/graded.R
+++ b/R/graded.R
@@ -470,8 +470,6 @@ fail_if <- function(
 #' # Perfect!
 #' grader(mock_this_exercise(runif(n = 5), !!.solution_code))
 #'
-#' @param env Environment used to standardize formals of the user and solution code.
-#'   Defaults to retrieving [.envir_result] and [.envir_solution] from [parent.frame()].
 #' @inheritParams code_feedback
 #' @inheritParams graded
 #' @inheritDotParams graded

--- a/R/graded.R
+++ b/R/graded.R
@@ -509,12 +509,14 @@ fail_if_code_feedback <- function(
     return()
   }
 
-  env_feedback <- get0(".envir_prep", env, ifnotfound = env)
+  user_env <- get0(".envir_result", env, ifnotfound = env)
+  solution_env <- get0(".envir_result", env, ifnotfound = env)
 
   feedback <- code_feedback(
     user_code = user_code,
     solution_code = solution_code,
-    env = env_feedback,
+    user_env = user_env,
+    solution_env = solution_env,
     allow_partial_matching = allow_partial_matching
   )
 

--- a/man/code_feedback.Rd
+++ b/man/code_feedback.Rd
@@ -9,7 +9,8 @@
 code_feedback(
   user_code = .user_code,
   solution_code = .solution_code_all,
-  env = .envir_prep,
+  user_env = .envir_result,
+  solution_env = .envir_solution,
   ...,
   allow_partial_matching = getOption("gradethis.allow_partial_matching", TRUE)
 )
@@ -17,7 +18,8 @@ code_feedback(
 maybe_code_feedback(
   user_code = get0(".user_code", parent.frame()),
   solution_code = get0(".solution_code_all", parent.frame()),
-  env = get0(".envir_prep", parent.frame(), ifnotfound = parent.frame()),
+  user_env = get0(".envir_result", parent.frame(), ifnotfound = parent.frame()),
+  solution_env = get0(".envir_solution", parent.frame(), ifnotfound = parent.frame()),
   ...,
   allow_partial_matching = getOption("gradethis.allow_partial_matching", TRUE),
   default = "",
@@ -42,10 +44,6 @@ solution variations, so by default in \code{\link[=grade_this]{grade_this()}} \l
 is found and used for \code{solution_code}. You may also use \code{.solution_code} if
 there is only one solution.}
 
-\item{env}{Environment used to standardize formals of the user and solution
-code. Defaults to retrieving \link{.envir_prep} from the calling environment. If
-not found, the \code{\link[=parent.frame]{parent.frame()}} will be used.}
-
 \item{...}{Ignored in \code{code_feedback()} and \code{maybe_code_feedback()}. In
 \code{give_code_feedback()}, \code{...} are passed to \code{maybe_code_feedback()}.}
 
@@ -69,6 +67,10 @@ of any incorrect grades using \code{\link[=maybe_code_feedback]{maybe_code_feedb
 include the code feedback, if possible. If \code{expr} is a character string,
 \code{"{maybe_code_feedback()}"} is pasted into the string, without
 customization.}
+
+\item{env}{Environment used to standardize formals of the user and solution
+code. Defaults to retrieving \link{.envir_prep} from the calling environment. If
+not found, the \code{\link[=parent.frame]{parent.frame()}} will be used.}
 
 \item{location}{Should the code feedback message be added before or after?}
 }

--- a/man/code_feedback.Rd
+++ b/man/code_feedback.Rd
@@ -76,6 +76,9 @@ include the code feedback, if possible. If \code{expr} is a character string,
 \code{"{maybe_code_feedback()}"} is pasted into the string, without
 customization.}
 
+\item{env}{Environment used to standardize formals of the user and solution code.
+Defaults to retrieving \link{.envir_result} and \link{.envir_solution} from \code{\link[=parent.frame]{parent.frame()}}.}
+
 \item{location}{Should the code feedback message be added before or after?}
 }
 \value{

--- a/man/code_feedback.Rd
+++ b/man/code_feedback.Rd
@@ -44,6 +44,14 @@ solution variations, so by default in \code{\link[=grade_this]{grade_this()}} \l
 is found and used for \code{solution_code}. You may also use \code{.solution_code} if
 there is only one solution.}
 
+\item{user_env}{Environment used to standardize formals of the user code.
+Defaults to retrieving \link{.envir_result} from the calling environment.
+If not found, the \code{\link[=parent.frame]{parent.frame()}} will be used.}
+
+\item{solution_env}{Environment used to standardize formals of the solution code.
+Defaults to retrieving \link{.envir_solution} from the calling environment.
+If not found, the \code{\link[=parent.frame]{parent.frame()}} will be used.}
+
 \item{...}{Ignored in \code{code_feedback()} and \code{maybe_code_feedback()}. In
 \code{give_code_feedback()}, \code{...} are passed to \code{maybe_code_feedback()}.}
 
@@ -67,10 +75,6 @@ of any incorrect grades using \code{\link[=maybe_code_feedback]{maybe_code_feedb
 include the code feedback, if possible. If \code{expr} is a character string,
 \code{"{maybe_code_feedback()}"} is pasted into the string, without
 customization.}
-
-\item{env}{Environment used to standardize formals of the user and solution
-code. Defaults to retrieving \link{.envir_prep} from the calling environment. If
-not found, the \code{\link[=parent.frame]{parent.frame()}} will be used.}
 
 \item{location}{Should the code feedback message be added before or after?}
 }

--- a/man/fail_if_code_feedback.Rd
+++ b/man/fail_if_code_feedback.Rd
@@ -42,9 +42,8 @@ details.
 \code{location} may be one of "append", "prepend", or "replace".}
   }}
 
-\item{env}{Environment used to standardize formals of the user and solution
-code. Defaults to retrieving \link{.envir_prep} from the calling environment. If
-not found, the \code{\link[=parent.frame]{parent.frame()}} will be used.}
+\item{env}{Environment used to standardize formals of the user and solution code.
+Defaults to retrieving \link{.envir_result} and \link{.envir_solution} from \code{\link[=parent.frame]{parent.frame()}}.}
 
 \item{hint}{Include a code feedback hint with the failing message? This
 argument only applies to \code{fail()} and \code{fail_if_equal()} and the message is
@@ -119,6 +118,7 @@ grader(mock_this_exercise(rbinom(5, 1, 0.5), !!.solution_code))
 
 # Perfect!
 grader(mock_this_exercise(runif(n = 5), !!.solution_code))
+
 }
 \seealso{
 Other grading helper functions: \code{\link[=graded]{graded()}}, \code{\link[=pass]{pass()}}, \code{\link[=fail]{fail()}},

--- a/tests/testthat/helper-expect.R
+++ b/tests/testthat/helper-expect.R
@@ -191,6 +191,7 @@ create_learnr_env <- function(
   env <- new.env(parent = envir_prep)
   env$.envir_prep <- envir_prep
   env$.envir_result <- new.env(parent = envir_prep)
+  env$.envir_solution <- new.env(parent = envir_prep)
   env$.user_code <- as.character(user_code)
   env$.solution_code <- as.character(solution_code)
   env$.solution_code_all <- solution_code_all
@@ -202,7 +203,7 @@ create_learnr_env <- function(
       if (is.null(solution_code)) {
         NULL
       } else {
-        eval(parse(text = solution_code), envir = new.env(parent = envir_prep))
+        eval(parse(text = solution_code), envir = env$.envir_solution)
       }
   }
 

--- a/tests/testthat/test-call_standarise_formals.R
+++ b/tests/testthat/test-call_standarise_formals.R
@@ -226,6 +226,22 @@ test_that("code_feedback() stadardizes arguments", {
       code_feedback()
     )
   )
+
+  expect_null(
+    with_exercise(
+      mock_this_exercise(
+        .user_code = "
+          foo <- function(bar, baz) bar + baz
+          purrr::map(1:10, foo, 2)
+        ",
+        .solution_code = "
+          foo <- function(bar, baz) bar + baz
+          purrr::map(1:10, foo, baz = 2)
+        "
+      ),
+      code_feedback()
+    )
+  )
 })
 
 test_that("When an invalid function passed (i.e., corrupt language object)", {

--- a/tests/testthat/test-call_standarise_formals.R
+++ b/tests/testthat/test-call_standarise_formals.R
@@ -204,6 +204,30 @@ test_that("Standardize call with passed ... args", {
   testthat::expect_equal(call_standardise_formals(d), xd)
 })
 
+test_that("code_feedback() stadardizes arguments", {
+  expect_null(
+    with_exercise(
+      mock_this_exercise(
+        .user_code = "foo(1, 2)",
+        .solution_code = "foo(bar = 1, baz = 2)",
+        setup_exercise = foo <- function(bar, baz) bar + baz
+      ),
+      code_feedback()
+    )
+  )
+
+  expect_null(
+    with_exercise(
+      mock_this_exercise(
+        .user_code = "purrr::map(1:10, foo, 2)",
+        .solution_code = "purrr::map(1:10, foo, baz = 2)",
+        setup_exercise = foo <- function(bar, baz) bar + baz
+      ),
+      code_feedback()
+    )
+  )
+})
+
 test_that("When an invalid function passed (i.e., corrupt language object)", {
   user <- quote(1(a(1)))
 

--- a/tests/testthat/test-detect_mistakes.R
+++ b/tests/testthat/test-detect_mistakes.R
@@ -619,7 +619,8 @@ test_that("detect_mistakes handles a mix of named and unnamed arguments and with
     detect_mistakes(
       quote(x %>% fn(name == "John")),
       quote(x %>% fn(name == "Paul")),
-      env = env
+      user_env = env,
+      solution_env = env
     ),
     message_wrong_value("John", "Paul", enclosing_call = quote(name == "John"))
   )
@@ -628,7 +629,8 @@ test_that("detect_mistakes handles a mix of named and unnamed arguments and with
     detect_mistakes(
       quote(fn(x, name == "John")),
       quote(fn(.data = x, name == "Paul")),
-      env = env
+      user_env = env,
+      solution_env = env
     ),
     message_wrong_value("John", "Paul", enclosing_call = quote(name == "John"))
   )
@@ -637,7 +639,8 @@ test_that("detect_mistakes handles a mix of named and unnamed arguments and with
     detect_mistakes(
       quote(fn(x = 1, 2)),
       quote(fn(x = 1)),
-      env = env
+      user_env = env,
+      solution_env = env
     ),
     message_surplus_argument(quote(fn()), quote(2), "")
   )
@@ -646,7 +649,8 @@ test_that("detect_mistakes handles a mix of named and unnamed arguments and with
     detect_mistakes(
       quote(fn(x = 1, 2)),
       quote(fn(x = 1)),
-      env = env
+      user_env = env,
+      solution_env = env
     ),
     message_surplus_argument(quote(fn()), quote(2), "")
   )

--- a/tests/testthat/test_sanity_checks.R
+++ b/tests/testthat/test_sanity_checks.R
@@ -157,13 +157,13 @@ test_that("detect_mistakes detects wrong calls", {
   solution <- quote(g(1))
   user <-     quote(g(1, y = a(1)))
   expect_null(
-    detect_mistakes(user, solution, env = testing_env)
+    detect_mistakes(user, solution, user_env = testing_env, solution_env = testing_env)
   )
 
   solution <- quote(g(1))
   user <-     quote(g(1, y = b(1)))
   expect_equal(
-    detect_mistakes(user, solution, env = testing_env),
+    detect_mistakes(user, solution, user_env = testing_env, solution_env = testing_env),
     message_wrong_call(
       submitted = user[[3]],
       solution = formals(g)[[2]],
@@ -175,7 +175,7 @@ test_that("detect_mistakes detects wrong calls", {
   solution <- quote(f(1, y = a(1)))
   user <-     quote(f(1, y = f(1)))
   expect_equal(
-    detect_mistakes(user, solution, env = testing_env),
+    detect_mistakes(user, solution, user_env = testing_env, solution_env = testing_env),
     message_wrong_call(
       submitted = user[[3]],
       solution = formals(g)[[2]],
@@ -360,7 +360,7 @@ test_that("detect_mistakes detects bad argument names", {
   solution <- quote(tricky(ab = 1))
   user <-     quote(tricky(a = 1))
   expect_equal(
-    detect_mistakes(user, solution, env = tricky_env),
+    detect_mistakes(user, solution, user_env = tricky_env, solution_env = tricky_env),
     message_bad_argument_name(
       submitted_call = user,
       submitted = user[[2]],
@@ -371,7 +371,7 @@ test_that("detect_mistakes detects bad argument names", {
   solution <- quote(tricky(ab = 1))
   user <-     quote(tricky(1, 2, a = 1))
   expect_equal(
-    detect_mistakes(user, solution, env = tricky_env),
+    detect_mistakes(user, solution, user_env = tricky_env, solution_env = tricky_env),
     message_bad_argument_name(
       submitted_call = user,
       submitted = user[[4]],
@@ -382,7 +382,7 @@ test_that("detect_mistakes detects bad argument names", {
   solution <- quote(tricky(ab = 1))
   user <-     quote(1 %>% tricky(a = 2))
   expect_equal(
-    detect_mistakes(user, solution, env = tricky_env),
+    detect_mistakes(user, solution, user_env = tricky_env, solution_env = tricky_env),
     message_bad_argument_name(
       submitted_call = user[[3]],
       submitted = user[[3]][[2]],
@@ -393,7 +393,7 @@ test_that("detect_mistakes detects bad argument names", {
   solution <- quote(tricky(ab = 1))
   user <-     quote(1 %>% tricky(a = .))
   expect_equal(
-    detect_mistakes(user, solution, env = tricky_env),
+    detect_mistakes(user, solution, user_env = tricky_env, solution_env = tricky_env),
     message_bad_argument_name(
       submitted_call = user[[3]],
       submitted = user[[2]],
@@ -412,7 +412,7 @@ test_that("detect_mistakes detects too many matches", {
   solution <- quote(tricky2(ambiguous = 2))
   user <-     quote(tricky2(a = 2, am = 2))
   expect_equal(
-    detect_mistakes(user, solution, env = tricky2_env),
+    detect_mistakes(user, solution, user_env = tricky2_env, solution_env = tricky2_env),
     message_too_many_matches(
       submitted_call = user,
       solution_name = names(as.list(solution)[2])
@@ -422,13 +422,13 @@ test_that("detect_mistakes detects too many matches", {
   solution <- quote(not_tricky(ambiguous = 2))
   user <-     quote(not_tricky(a = 1, am = 2))
   expect_null(
-    suppressWarnings(detect_mistakes(user, solution, env = tricky2_env))
+    suppressWarnings(detect_mistakes(user, solution, user_env = tricky2_env, solution_env = tricky2_env))
   )
 
   solution <- quote(tricky2(ambiguous = 2))
   user <-     quote(2 %>% tricky2(a = ., am = 2))
   expect_equal(
-    detect_mistakes(user, solution, env = tricky2_env),
+    detect_mistakes(user, solution, user_env = tricky2_env, solution_env = tricky2_env),
     message_too_many_matches(
       submitted_call = user[[3]],
       solution_name = names(as.list(solution)[2])
@@ -535,7 +535,7 @@ test_that("detect_mistakes detects missing argument", {
   solution <- quote(f(x = 1, y = 1))
   user <-     quote(f(1))
   expect_equal(
-    detect_mistakes(user, solution, env = testing_env),
+    detect_mistakes(user, solution, user_env = testing_env, solution_env = testing_env),
     message_missing_argument(
       submitted_call = user,
       solution_name = names(as.list(solution)[3])
@@ -545,7 +545,7 @@ test_that("detect_mistakes detects missing argument", {
   solution <- quote(f(x = 1, y = 1))
   user <-     quote(1 %>% f())
   expect_equal(
-    detect_mistakes(user, solution, env = testing_env),
+    detect_mistakes(user, solution, user_env = testing_env, solution_env = testing_env),
     message_missing_argument(
       submitted_call = user[[3]],
       solution_name = names(as.list(solution)[3])
@@ -555,7 +555,7 @@ test_that("detect_mistakes detects missing argument", {
   solution <- quote(a(f(x = 1, y = 1)))
   user <-     quote(a(1 %>% f()))
   expect_equal(
-    detect_mistakes(user, solution, env = testing_env),
+    detect_mistakes(user, solution, user_env = testing_env, solution_env = testing_env),
     message_missing_argument(
       submitted_call = user[[2]][[3]],
       solution_name = names(as.list(solution[[2]])[3]),


### PR DESCRIPTION
This PR modifies `code_feedback()` to now pass two environments to `call_standardise()`:
- `.user_code` is now standardized in `.envir_result`
- `.solution_code` is now standardized in `.envir_solution`
Previously, both were standardized in `.envir_prep`.
This allows `call_standardise()` to standardize arguments to functions defined within the code itself, because `.envir_prep` only contains definitions of functions defined before user and solution code is evaluated.'

This PR also ensures that all functions that touch `call_standardise()` pass these environments. Previously, the environment would be dropped in some calls to call standardizing functions, meaning some arguments would end up unstandardized. 

``` r
library(gradethis)

# Arguments passed to package functions are standardized
with_exercise(
  mock_this_exercise(
    .user_code = "purrr::map(1:10, rnorm, 1)",
    .solution_code = "purrr::map(1:10, rnorm, mean = 1)"
  ),
  code_feedback()
)
#> NULL

# Arguments passed to functions defined in setup are standardized
with_exercise(
  mock_this_exercise(
    .user_code = "purrr::map(1:10, foo, 1)",
    .solution_code = "purrr::map(1:10, foo, baz = 1)",
    setup_exercise = foo <- function(bar, baz) bar + baz
  ),
  code_feedback()
)
#> NULL

# Arguments passed to functions defined in user code are standardized
with_exercise(
  mock_this_exercise(
    .user_code = "
        foo <- function(bar, baz) bar + baz
        purrr::map(1:10, foo, 2)
      ",
    .solution_code = "
        foo <- function(bar, baz) bar + baz
        purrr::map(1:10, foo, baz = 2)
      "
  ),
  code_feedback()
)
#> NULL
```

<sup>Created on 2023-05-15 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Closes #349.