### PR TITLE
Add fallback in `grade_code()` if `.envir_result` or `.envir_solution` is missing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gradethis
 Title: Automated Feedback for Student Exercises in 'learnr' Tutorials
-Version: 0.2.13
+Version: 0.2.13.9000
 Authors@R: c(
     person("Garrick", "Aden-Buie", , "garrick@posit.co", role = "aut",
            comment = c(ORCID = "0000-0002-7111-0077")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gradethis (development version)
 
+* `grade_code()` no longer fails if `.envir_result` or `.envir_solution` is missing (#355).
+
 # gradethis 0.2.13
 
 * `code_feedback()` now standardizes arguments to functions defined within student and solution code before comparing code. It also now successfully standardizes arguments passed through `...` by mapping functions into functions defined by setup code (#349).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# gradethis (development version)
+
 # gradethis 0.2.13
 
 * `code_feedback()` now standardizes arguments to functions defined within student and solution code before comparing code. It also now successfully standardizes arguments passed through `...` by mapping functions into functions defined by setup code (#349).

--- a/R/grade_code.R
+++ b/R/grade_code.R
@@ -136,8 +136,8 @@ grade_code <- function(
     message <- code_feedback(
       user_code = user_code,
       solution_code = solution_code_all,
-      user_env = check_env$.envir_result,
-      solution_env = check_env$.envir_solution,
+      user_env = check_env$.envir_result %||% check_env,
+      solution_env = check_env$.envir_solution %||% check_env,
       allow_partial_matching = allow_partial_matching
     )
 


### PR DESCRIPTION
If `check_env` does not contain `.envir_result` or `.envir_solution`, use`check_env` instead.