### PR TITLE
Refactor `detect_mistakes()` to keep two standardized versions of `.user_code` and `.solution_code`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gradethis
 Title: Automated Feedback for Student Exercises in 'learnr' Tutorials
-Version: 0.2.13
+Version: 0.2.13.9000
 Authors@R: c(
     person("Garrick", "Aden-Buie", , "garrick@posit.co", role = "aut",
            comment = c(ORCID = "0000-0002-7111-0077")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # gradethis (development version)
 
+* `detect_mistakes()` now keeps a version of standardized user and solution code with and without default arguments added. Missing arguments are detected by comparing the user code with defaults to the solution code without defaults. Surplus arguments are detected by comparing the user code without defaults to the solution code with defaults (#356).
+    * This helps avoid spurious feedback when comparing code that involves S3 methods. If the user's code differs from the solution code in a way that means a different S3 method is used, the standardized code may gain different default arguments. This could result in feedback about missing or surplus arguments that were added by code standardization rather than by the student, which is not actionable feedback. By no longer looking for default arguments that are missing or surplus in the user code, we ensure that students receive more actionable feedback, likely about the incorrect argument that resulted in the use of a different S3 method.
+
 # gradethis 0.2.13
 
 * `code_feedback()` now standardizes arguments to functions defined within student and solution code before comparing code. It also now successfully standardizes arguments passed through `...` by mapping functions into functions defined by setup code (#349).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# gradethis (development version)
+
 # gradethis 0.2.13
 
 * `code_feedback()` now standardizes arguments to functions defined within student and solution code before comparing code. It also now successfully standardizes arguments passed through `...` by mapping functions into functions defined by setup code (#349).

--- a/tests/testthat/test-code_feedback.R
+++ b/tests/testthat/test-code_feedback.R
@@ -74,6 +74,16 @@ test_that("to_expr() accepts quosures or strings", {
   expect_error(to_expr(42))
 })
 
+test_that("code_feedback() works with S3 methods", {
+  expect_equal(
+    gradethis::code_feedback(
+      "mydata <- head(THIS_VARIABLE_DOES_NOT_EXIST)",
+      "mydata <- head(mtcars)"
+    ),
+    "In `head(THIS_VARIABLE_DOES_NOT_EXIST)`, I expected `mtcars` where you wrote `THIS_VARIABLE_DOES_NOT_EXIST`."
+  )
+})
+
 # maybe_code_feedback() ---------------------------------------------------
 
 test_that("maybe_code_feedback() formals match with code_feedback()", {


### PR DESCRIPTION
`detect_mistakes()` now keeps a version of standardized user and solution code with and without default arguments added. Missing arguments are detected by comparing the user code with defaults to the solution code without defaults. Surplus arguments are detected by comparing the user code without defaults to the solution code with defaults.

This helps avoid spurious feedback when comparing code that involves S3 methods. If the user's code differs from the solution code in a way that means a different S3 method is used, the standardized code may gain different default arguments. This could result in feedback about missing or surplus arguments that were added by code standardization rather than by the student, which is not actionable feedback. By no longer looking for default arguments that are missing or surplus in the user code, we ensure that students receive more actionable feedback, likely about the incorrect argument that resulted in the use of a different S3 method.