### PR TITLE
Only use `gradethis_equal.list()` method if both objects are bare lists

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * `grade_code()` no longer fails if `.envir_result` or `.envir_solution` is missing (#355).
 * `detect_mistakes()` now keeps a version of standardized user and solution code with and without default arguments added. Missing arguments are detected by comparing the user code with defaults to the solution code without defaults. Surplus arguments are detected by comparing the user code without defaults to the solution code with defaults (#356).
     * This helps avoid spurious feedback when comparing code that involves S3 methods. If the user's code differs from the solution code in a way that means a different S3 method is used, the standardized code may gain different default arguments. This could result in feedback about missing or surplus arguments that were added by code standardization rather than by the student, which is not actionable feedback. By no longer looking for default arguments that are missing or surplus in the user code, we ensure that students receive more actionable feedback, likely about the incorrect argument that resulted in the use of a different S3 method.
+* The `gradethis_equal.list()` method is now only used if both `x` and `y` are bare lists (as defined by `rlang::is_bare_list()`) (#357).
+    * This fixes a bug where a list could be marked as equal to another object with the same contents but a different class, e.g. `list(a = 1, b = 2)` and `c(a = 1, b = 2)` or `data.frame(a = 1, b = 2)`.
 
 # gradethis 0.2.13
 

--- a/R/gradethis_equal.R
+++ b/R/gradethis_equal.R
@@ -63,7 +63,7 @@ gradethis_equal.list <- function(
   # Only use this method for objects of class `list`,
   # not just anything that inherits list (like data frames)
   if (!rlang::is_bare_list(x) || !rlang::is_bare_list(y)) {
-    NextMethod()
+    return(NextMethod())
   }
 
   # First check with `identical()`, since it's fast

--- a/tests/testthat/test-gradethis_equal.R
+++ b/tests/testthat/test-gradethis_equal.R
@@ -2,6 +2,13 @@ test_that("gradethis_equal.list() checks names", {
   expect_false(gradethis_equal(list(pi, letters), list(a = pi, b = letters)))
 })
 
+test_that("gradethis_equal() distinguishes lists from vectors", {
+  expect_false(gradethis_equal(as.list(letters), letters))
+  expect_false(gradethis_equal(letters, as.list(letters)))
+  expect_false(gradethis_equal(list(as.list(letters)), list(letters)))
+  expect_false(gradethis_equal(list(letters), list(as.list(letters))))
+})
+
 test_that("gradethis_equal uses methods from ggcheck", {
   skip_if_not_installed("ggcheck", "0.0.5")
   skip_if_not_installed("ggplot2")

--- a/tests/testthat/test-gradethis_equal.R
+++ b/tests/testthat/test-gradethis_equal.R
@@ -2,11 +2,22 @@ test_that("gradethis_equal.list() checks names", {
   expect_false(gradethis_equal(list(pi, letters), list(a = pi, b = letters)))
 })
 
-test_that("gradethis_equal() distinguishes lists from vectors", {
-  expect_false(gradethis_equal(as.list(letters), letters))
-  expect_false(gradethis_equal(letters, as.list(letters)))
-  expect_false(gradethis_equal(list(as.list(letters)), list(letters)))
-  expect_false(gradethis_equal(list(letters), list(as.list(letters))))
+test_that("gradethis_equal.list() is only used when x and y are both bare lists", {
+  example_list <- list(1, 2, 3)
+  example_vector <- c(1, 2, 3)
+
+  expect_false(gradethis_equal(example_list, example_vector))
+  expect_false(gradethis_equal(example_vector, example_list))
+  expect_false(gradethis_equal(list(example_list), list(example_vector)))
+  expect_false(gradethis_equal(list(example_vector), list(example_list)))
+
+  example_list <- list(a = 1, b = 2)
+  example_data_frame <- data.frame(a = 1, b = 2)
+
+  expect_false(gradethis_equal(example_list, example_data_frame))
+  expect_false(gradethis_equal(example_data_frame, example_list))
+  expect_false(gradethis_equal(list(example_list), list(example_data_frame)))
+  expect_false(gradethis_equal(list(example_data_frame), list(example_list)))
 })
 
 test_that("gradethis_equal uses methods from ggcheck", {


### PR DESCRIPTION
Fixes a bug where a list and an equivalent vector would be marked as equal, e.g. `list(1, 2, 3)` and `c(1, 2, 3)`.