### PR TITLE
Standardize `map()` when `.f` is an index rather than a function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
     * This helps avoid spurious feedback when comparing code that involves S3 methods. If the user's code differs from the solution code in a way that means a different S3 method is used, the standardized code may gain different default arguments. This could result in feedback about missing or surplus arguments that were added by code standardization rather than by the student, which is not actionable feedback. By no longer looking for default arguments that are missing or surplus in the user code, we ensure that students receive more actionable feedback, likely about the incorrect argument that resulted in the use of a different S3 method.
 * The `gradethis_equal.list()` method is now only used if both `x` and `y` are bare lists (as defined by `rlang::is_bare_list()`) (#357).
     * This fixes a bug where a list could be marked as equal to another object with the same contents but a different class, e.g. `list(a = 1, b = 2)` and `c(a = 1, b = 2)` or `data.frame(a = 1, b = 2)`.
+* Fix bug where `call_standardise_formals()` would fail when given a `purrr::map()` function where `.f` is an index rather than a function (#359).
 
 # gradethis 0.2.13
 

--- a/tests/testthat/test-call_standardise_formals.R
+++ b/tests/testthat/test-call_standardise_formals.R
@@ -155,6 +155,21 @@ test_that("Standardize call with passed ... args", {
 
   expect_equal(
     call_standardise_formals(quote(
+      purrr::map2(list(1:2, 1:3), list(1:2, 1:3), mean, TRUE)
+    )),
+    quote(
+      purrr::map2(
+        .x = list(1:2, 1:3),
+        .y = list(1:2, 1:3),
+        .f = mean,
+        na.rm = TRUE,
+        .progress = FALSE
+      )
+    )
+  )
+
+  expect_equal(
+    call_standardise_formals(quote(
       purrr::imap(c("0" = 1), mean, TRUE)
     )),
     quote(
@@ -180,6 +195,20 @@ test_that("Standardize call with passed ... args", {
     )
   )
 
+  expect_equal(
+    call_standardise_formals(quote(
+      purrr::pmap(list(list(1:2, 1:3), list(1:2, 1:3)), mean, TRUE)
+    )),
+    quote(
+      purrr::pmap(
+        .l = list(list(1:2, 1:3), list(1:2, 1:3)),
+        .f = mean,
+        na.rm = TRUE,
+        .progress = FALSE
+      )
+    )
+  )
+
   a <- quote(vapply(list(1:3, 4:6), mean, numeric(1), 0, TRUE))
   b <- quote(vapply(list(1:3, 4:6), mean, numeric(1), trim = 0, TRUE))
   c <- quote(vapply(list(1:3, 4:6), mean, numeric(1), 0, na.rm = TRUE))
@@ -202,6 +231,30 @@ test_that("Standardize call with passed ... args", {
   testthat::expect_equal(call_standardise_formals(b), xd)
   testthat::expect_equal(call_standardise_formals(c), xd)
   testthat::expect_equal(call_standardise_formals(d), xd)
+})
+
+test_that("Standardize map() when .f is an index", {
+  expect_equal(
+    call_standardise_formals(quote(
+      purrr::map(list(c(1, 2), c("a", "b")), 2)
+    )),
+    quote(
+      purrr::map(.x = list(c(1, 2), c("a", "b")), .f = 2, .progress = FALSE)
+    )
+  )
+
+  expect_equal(
+    call_standardise_formals(quote(
+      purrr::map(list(c(a = 1, b = 2), c(a = "a", b = "b")), "b")
+    )),
+    quote(
+      purrr::map(
+        .x = list(c(a = 1, b = 2), c(a = "a", b = "b")),
+        .f = "b",
+        .progress = FALSE
+      )
+    )
+  )
 })
 
 test_that("Standardize call with ggplot2 functions", {


### PR DESCRIPTION
``` r
list <- list(
  c(1, 2),
  c("a", "b")
)

call <- quote(purrr::map(list, 2))

gradethis:::call_standardise_formals(call)
#> purrr::map(.x = list, .f = 2, .progress = FALSE)
```

<sup>Created on 2023-06-13 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Closes #358.